### PR TITLE
Fixing an issue in validating ranges while splitting non-root shards

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/metadata/SplitShardsMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/SplitShardsMetadata.java
@@ -140,10 +140,10 @@ public class SplitShardsMetadata extends AbstractDiffable<SplitShardsMetadata> i
         return emptyParents;
     }
 
-    private static void validateShardRanges(int shardId, ShardRange[] shardRanges) {
+    private static void validateShardRanges(int shardId, ShardRange[] shardRanges, long parentStart, long parentEnd) {
         Integer start = null;
         for (ShardRange shardRange : shardRanges) {
-            validateBounds(shardRange, start);
+            validateBounds(shardRange, start, parentStart);
             long rangeEnd = shardRange.getEnd();
             long rangeLength = rangeEnd - shardRange.getStart() + 1;
             if (rangeLength < MINIMUM_RANGE_LENGTH_THRESHOLD) {
@@ -159,18 +159,18 @@ public class SplitShardsMetadata extends AbstractDiffable<SplitShardsMetadata> i
             throw new IllegalArgumentException("No shard range defined for child shards of shard " + shardId);
         }
 
-        if (start != Integer.MAX_VALUE) {
+        if (start != parentEnd) {
             throw new IllegalArgumentException(
-                "Shard range from " + (start + 1) + " to " + Integer.MAX_VALUE
+                "Shard range from " + (start + 1) + " to " + parentEnd
                     + " is missing from the list of shard ranges");
         }
     }
 
-    private static void validateBounds(ShardRange shardRange, Integer start) {
+    private static void validateBounds(ShardRange shardRange, Integer start, long parentStart) {
         if (start == null) {
-            if (shardRange.getStart() != Integer.MIN_VALUE) {
+            if (shardRange.getStart() != parentStart) {
                 throw new IllegalArgumentException(
-                    "Shard range from " + Integer.MIN_VALUE + " to " + (shardRange.getStart() - 1)
+                    "Shard range from " + parentStart + " to " + (shardRange.getStart() - 1)
                         + " is missing from the list of shard ranges");
             }
         } else if (shardRange.getStart() != start + 1) {
@@ -253,7 +253,7 @@ public class SplitShardsMetadata extends AbstractDiffable<SplitShardsMetadata> i
                 start = end + 1;
             }
             ShardRange[] newShardRanges = newChildShardsList.toArray(new ShardRange[0]);
-            validateShardRanges(splitShardId, newShardRanges);
+            validateShardRanges(splitShardId, newShardRanges, parentShard.getStart(), parentShard.getEnd());
 
             parentToChildShards.put(splitShardId, newShardRanges);
         }
@@ -273,7 +273,7 @@ public class SplitShardsMetadata extends AbstractDiffable<SplitShardsMetadata> i
             shardsUnderRoot.addAll(Arrays.asList(parentToChildShards.get(sourceShardId)));
             ShardRange[] newShardsUnderRoot = shardsUnderRoot.toArray(new ShardRange[0]);
             Arrays.sort(newShardsUnderRoot);
-            validateShardRanges(shardRangeTuple.v1(), newShardsUnderRoot);
+            validateShardRanges(shardRangeTuple.v1(), newShardsUnderRoot, Integer.MIN_VALUE, Integer.MAX_VALUE);
 
             maxShardId += newChildShardIds.size();
             rootShardsToAllChildren[shardRangeTuple.v1()] = newShardsUnderRoot;


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Fixing an issue in validating ranges while splitting non-root shards

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] Functionality includes testing.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
