### PR TITLE
update equality check in SplitShardsMetadata with deep equality check on parentToChildShards map

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/metadata/SplitShardsMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/SplitShardsMetadata.java
@@ -335,6 +335,7 @@ public class SplitShardsMetadata extends AbstractDiffable<SplitShardsMetadata> i
         if (maxShardId != that.maxShardId) return false;
         if (inProgressSplitShardId != that.inProgressSplitShardId) return false;
         if (!Arrays.deepEquals(rootShardsToAllChildren, that.rootShardsToAllChildren)) return false;
+        if(parentToChildShards.size() != that.parentToChildShards.size()) return false;
         for (Integer key : parentToChildShards.keySet()) {
             if (!Arrays.deepEquals(parentToChildShards.get(key), that.parentToChildShards.get(key))) {
                 return false;

--- a/server/src/main/java/org/opensearch/cluster/metadata/SplitShardsMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/SplitShardsMetadata.java
@@ -335,7 +335,17 @@ public class SplitShardsMetadata extends AbstractDiffable<SplitShardsMetadata> i
         if (maxShardId != that.maxShardId) return false;
         if (inProgressSplitShardId != that.inProgressSplitShardId) return false;
         if (!Arrays.deepEquals(rootShardsToAllChildren, that.rootShardsToAllChildren)) return false;
-        return parentToChildShards.equals(that.parentToChildShards);
+        boolean parentToChildShardsEquals = true;
+        for (Integer key : parentToChildShards.keySet()) {
+            if (
+                !that.parentToChildShards.containsKey(key) ||
+                !Arrays.deepEquals(parentToChildShards.get(key), that.parentToChildShards.get(key))
+            ) {
+                parentToChildShardsEquals = false;
+                break;
+            }
+        }
+        return parentToChildShardsEquals;
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/cluster/metadata/SplitShardsMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/SplitShardsMetadata.java
@@ -335,18 +335,12 @@ public class SplitShardsMetadata extends AbstractDiffable<SplitShardsMetadata> i
         if (maxShardId != that.maxShardId) return false;
         if (inProgressSplitShardId != that.inProgressSplitShardId) return false;
         if (!Arrays.deepEquals(rootShardsToAllChildren, that.rootShardsToAllChildren)) return false;
-        boolean parentToChildShardsEquals = true;
         for (Integer key : parentToChildShards.keySet()) {
-            if (
-                !that.parentToChildShards.containsKey(key) ||
-                !Arrays.deepEquals(parentToChildShards.get(key), that.parentToChildShards.get(key))
-            ) {
-                parentToChildShardsEquals = false;
-                break;
+            if (!Arrays.deepEquals(parentToChildShards.get(key), that.parentToChildShards.get(key))) {
+                return false;
             }
         }
-        return parentToChildShardsEquals;
-    }
+        return true;
 
     @Override
     public int hashCode() {


### PR DESCRIPTION
This PR updates equality check in `SplitShardsMetadata` with deep equality check on `parentToChildShards` map whose value is an Array type. 

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
