### PR TITLE
avoids skipping validation checks for numberOfShards setting when buil…

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
@@ -1754,7 +1754,8 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
                 throw new IllegalArgumentException("must specify number of shards for index [" + index + "]");
             }
             if (splitShardsMetadata == null) {
-                this.splitShardsMetadata = new SplitShardsMetadata.Builder(numberOfShards()).build();
+                int numberOfShards = INDEX_NUMBER_OF_SHARDS_SETTING.get(settings);
+                this.splitShardsMetadata = new SplitShardsMetadata.Builder(numberOfShards).build();
             }
             final int numberOfShards = splitShardsMetadata.getNumberOfShards();
 


### PR DESCRIPTION
…ding IndexMetadata

With split changes, we've added SplitShardsMetadata. This object is instantiated in IndexMetadata.Builder' flow using the numberOfShards. We were invoking numberOfShards() which skips the validation check for the INDEX_NUMBER_OF_SHARDS_SETTING setting as it directly fetches the setting via `settings.getAsInt()`.

Changing this to fetch this setting via INDEX_NUMBER_OF_SHARDS_SETTING.get(settings) so that validations work correctly.

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
