### PR TITLE
Adding UTs for shard split changes

### DIFF
--- a/server/src/test/java/org/opensearch/cluster/metadata/ShardRangeTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/ShardRangeTests.java
@@ -1,0 +1,440 @@
+package org.opensearch.cluster.metadata;
+
+import org.junit.Test;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.LoggingDeprecationHandler;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+import static org.junit.Assert.*;
+
+public class ShardRangeTests {
+
+
+    /**
+     * Test compareTo method with equal start values
+     */
+    @Test
+    public void testCompareToWithEqualStartValues() {
+        ShardRange range1 = new ShardRange(1, 0, 100);
+        ShardRange range2 = new ShardRange(2, 0, 200);
+
+        assertEquals(0, range1.compareTo(range2));
+    }
+
+    /**
+     * Test compareTo method with overlapping ranges
+     */
+    @Test
+    public void testCompareToWithOverlappingRanges() {
+        ShardRange range1 = new ShardRange(1, 0, 100);
+        ShardRange range2 = new ShardRange(2, 50, 150);
+
+        assertTrue(range1.compareTo(range2) < 0);
+        assertTrue(range2.compareTo(range1) > 0);
+    }
+
+    /**
+     * Test compareTo method with null input
+     */
+    @Test
+    public void testCompareToWithNull() {
+        ShardRange range = new ShardRange(1, 0, 100);
+        assertThrows(NullPointerException.class, () -> range.compareTo(null));
+    }
+
+
+    @Test
+    public void testContainsWithHashInBetween() {
+        /**
+         * Test that the contains method returns true when the hash is equal to the end value.
+         */
+        ShardRange shardRange = new ShardRange(0, 10, 20);
+        assertTrue(shardRange.contains(15));
+    }
+
+    @Test
+    public void testContainsWithHashEqualToEnd() {
+        /**
+         * Test that the contains method returns true when the hash is equal to the end value.
+         */
+        ShardRange shardRange = new ShardRange(0, 10, 20);
+        assertTrue(shardRange.contains(20));
+    }
+
+    @Test
+    public void testContainsWithHashEqualToStart() {
+        /**
+         * Test that the contains method returns true when the hash is equal to the start value.
+         */
+        ShardRange shardRange = new ShardRange(0, 10, 20);
+        assertTrue(shardRange.contains(10));
+    }
+
+    @Test
+    public void testContainsWithHashGreaterThanEnd() {
+        /**
+         * Test that the contains method returns false when the hash is greater than the end value.
+         */
+        ShardRange shardRange = new ShardRange(0, 10, 20);
+        assertFalse(shardRange.contains(25));
+    }
+
+    @Test
+    public void testContainsWithHashLessThanStart() {
+        /**
+         * Test that the contains method returns false when the hash is less than the start value.
+         */
+        ShardRange shardRange = new ShardRange(0, 10, 20);
+        assertFalse(shardRange.contains(5));
+    }
+
+    @Test
+    public void testContainsWithNegativeHash() {
+        /**
+         * Test that the contains method handles negative hash values correctly.
+         */
+        ShardRange shardRange = new ShardRange(0, -10, 10);
+        assertTrue(shardRange.contains(-5));
+        assertFalse(shardRange.contains(-15));
+    }
+
+    /**
+     * Test that the copy method creates a new object with the same values.
+     */
+    @Test
+    public void testCopyCreatesNewObjectWithSameValues() {
+        ShardRange original = new ShardRange(1, 0, 100);
+        ShardRange copy = original.copy();
+
+        assertNotSame("Copy should be a new object", original, copy);
+        assertEquals("ShardId should be the same", original.getShardId(), copy.getShardId());
+        assertEquals("Start should be the same", original.getStart(), copy.getStart());
+        assertEquals("End should be the same", original.getEnd(), copy.getEnd());
+    }
+
+    /**
+     * Test that modifying the copy doesn't affect the original.
+     */
+    @Test
+    public void testCopyIsIndependentOfOriginal() {
+        ShardRange original = new ShardRange(1, 0, 100);
+        ShardRange copy = original.copy();
+
+        // Attempt to modify the copy (this won't actually work because ShardRange is immutable,
+        // but it illustrates the point)
+        ShardRange modifiedCopy = new ShardRange(copy.getShardId() + 1, copy.getStart() + 10, copy.getEnd() + 10);
+
+        assertNotEquals("Original should not be affected by changes to copy", original.getShardId(), modifiedCopy.getShardId());
+        assertNotEquals("Original should not be affected by changes to copy", original.getStart(), modifiedCopy.getStart());
+        assertNotEquals("Original should not be affected by changes to copy", original.getEnd(), modifiedCopy.getEnd());
+    }
+
+    /**
+     * Tests the equals method of ShardRange class for various scenarios.
+     */
+    @Test
+    public void testEqualsMethod() {
+        // Create ShardRange objects for testing
+        ShardRange range1 = new ShardRange(1, 0, 100);
+        ShardRange range2 = new ShardRange(1, 0, 100);
+        ShardRange range3 = new ShardRange(2, 0, 100);
+        ShardRange range4 = new ShardRange(1, 10, 100);
+        ShardRange range5 = new ShardRange(1, 0, 90);
+
+        // Test equality with itself
+        assertTrue("A ShardRange should be equal to itself", range1.equals(range1));
+
+        // Test equality with an identical ShardRange
+        assertTrue("Two identical ShardRanges should be equal", range1.equals(range2));
+
+        // Test inequality with different shardId
+        assertFalse("ShardRanges with different shardIds should not be equal", range1.equals(range3));
+
+        // Test inequality with different start value
+        assertFalse("ShardRanges with different start values should not be equal", range1.equals(range4));
+
+        // Test inequality with different end value
+        assertFalse("ShardRanges with different end values should not be equal", range1.equals(range5));
+
+        // Test inequality with null
+        assertFalse("A ShardRange should not be equal to null", range1.equals(null));
+    }
+
+    /**
+     * Test case for getEnd() method of ShardRange class
+     * Verifies that the method correctly returns the end value
+     */
+    @Test
+    public void testGetEndReturnsCorrectValue() {
+        // Arrange
+        int expectedEnd = 100;
+        ShardRange shardRange = new ShardRange(0, 0, expectedEnd);
+
+        // Act
+        int actualEnd = shardRange.getEnd();
+
+        // Assert
+        assertEquals("getEnd() should return the correct end value", expectedEnd, actualEnd);
+    }
+
+    /**
+     * Test case for getShardId() method
+     * Verifies that the method correctly returns the shard ID
+     */
+    @Test
+    public void testGetShardIdReturnsCorrectValue() {
+        // Arrange
+        int expectedShardId = 5;
+        ShardRange shardRange = new ShardRange(expectedShardId, 0, 100);
+
+        // Act
+        int actualShardId = shardRange.getShardId();
+
+        // Assert
+        assertEquals("getShardId() should return the correct shard ID", expectedShardId, actualShardId);
+    }
+
+    /**
+     * Test that getStart returns the correct value for a valid ShardRange
+     */
+    @Test
+    public void testGetStartReturnsCorrectValue() {
+        ShardRange shardRange = new ShardRange(1, 100, 200);
+        assertEquals(100, shardRange.getStart());
+    }
+
+    /**
+     * Test hashCode() consistency for equal objects
+     */
+    @Test
+    public void testHashCodeConsistency() {
+        ShardRange shardRange1 = new ShardRange(1, 100, 200);
+        ShardRange shardRange2 = new ShardRange(1, 100, 200);
+        assertEquals(shardRange1.hashCode(), shardRange2.hashCode());
+    }
+
+    /**
+     * Test hashCode() with zero values for all fields
+     */
+    @Test
+    public void testHashCodeWithZeroValues() {
+        ShardRange shardRange = new ShardRange(0, 0, 0);
+        assertEquals(0, shardRange.hashCode());
+    }
+
+    /**
+     * Test the toString method of ShardRange
+     * Verifies that the toString method returns the expected string representation
+     */
+    @Test
+    public void testToStringReturnsCorrectRepresentation() {
+        // Arrange
+        int shardId = 1;
+        int start = 0;
+        int end = 100;
+        ShardRange shardRange = new ShardRange(shardId, start, end);
+
+        // Act
+        String result = shardRange.toString();
+
+        // Assert
+        String expected = "ShardRange{shardId=1, start=0, end=100}";
+        assertEquals("The toString method should return the correct string representation", expected, result);
+    }
+
+    /**
+     * Test that toXContent correctly serializes a ShardRange object to JSON
+     */
+    @Test
+    public void testToXContentSerializesShardRangeCorrectly() throws IOException {
+        int shardId = 1;
+        int start = 0;
+        int end = 100;
+        ShardRange shardRange = new ShardRange(shardId, start, end);
+
+        XContentBuilder builder = XContentFactory.jsonBuilder();  // Changed from contentBuilder
+        builder = shardRange.toXContent(builder, null);
+
+        String expected = "{\"shard_id\":1,\"start\":0,\"end\":100}";
+        assertEquals(expected, builder.toString());  // Also switched the order of expected and actual
+    }
+
+    @Test
+    public void testToXContentWithNullBuilder() {
+        /**
+         * Test toXContent method with null XContentBuilder
+         * This test verifies that a NullPointerException is thrown when a null XContentBuilder is provided
+         */
+        ShardRange shardRange = new ShardRange(1, 0, 100);
+        assertThrows(NullPointerException.class, () -> shardRange.toXContent(null, null));
+    }
+
+    @Test
+    public void testToXContentIOException() throws IOException {
+        ShardRange shardRange = new ShardRange(1, 0, 100);
+
+        // Create a real XContentBuilder that writes to a broken OutputStream
+        OutputStream failingStream = new OutputStream() {
+            @Override
+            public void write(int b) throws IOException {
+                throw new IOException("Simulated IOException");
+            }
+
+            @Override
+            public void write(byte[] b) throws IOException {
+                throw new IOException("Simulated IOException");
+            }
+
+            @Override
+            public void write(byte[] b, int off, int len) throws IOException {
+                throw new IOException("Simulated IOException");
+            }
+        };
+
+        XContentBuilder builder = XContentFactory.jsonBuilder(failingStream);
+        builder.startObject(); // Start the JSON object
+
+        // The actual test - this should throw IOException when trying to write
+        assertThrows(IOException.class, () -> {
+            shardRange.toXContent(builder, null);
+            builder.endObject(); // End the JSON object
+            builder.close(); // Force flush/close which will trigger the write
+        });
+    }
+
+    @Test
+    public void testWriteToWithIOException() {
+        /**
+         * Test that writeTo properly propagates IOException
+         */
+        ShardRange shardRange = new ShardRange(1, 0, 100);
+        StreamOutput failingOutput = new StreamOutput() {
+            @Override
+            public void writeByte(byte b) throws IOException {
+                throw new IOException("Simulated IO failure");
+            }
+
+            @Override
+            public void writeBytes(byte[] b, int offset, int length) throws IOException {
+                throw new IOException("Simulated IO failure");
+            }
+
+            @Override
+            public void flush() throws IOException {
+                throw new IOException("Simulated IO failure");
+            }
+
+            @Override
+            public void close() throws IOException {
+                throw new IOException("Simulated IO failure");
+            }
+
+            @Override
+            public void reset() throws IOException {
+                throw new IOException("Simulated IO failure");
+            }
+        };
+
+        assertThrows(IOException.class, () -> shardRange.writeTo(failingOutput));
+    }
+
+    @Test
+    public void testWriteToWithNullStreamOutput() {
+        /**
+         * Test that writeTo throws NullPointerException when StreamOutput is null
+         */
+        ShardRange shardRange = new ShardRange(1, 0, 100);
+        assertThrows(NullPointerException.class, () -> shardRange.writeTo(null));
+    }
+
+    /**
+     * Test that the writeTo method correctly writes the ShardRange data to the stream
+     * and that it can be read back correctly.
+     */
+    @Test
+    public void testWriteToCorrectlySerializesAndDeserializes() throws IOException {
+        int shardId = 1;
+        int start = 100;
+        int end = 200;
+        ShardRange originalShardRange = new ShardRange(shardId, start, end);
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        originalShardRange.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        ShardRange deserializedShardRange = new ShardRange(in);
+
+        assertEquals(originalShardRange.getShardId(), deserializedShardRange.getShardId());
+        assertEquals(originalShardRange.getStart(), deserializedShardRange.getStart());
+        assertEquals(originalShardRange.getEnd(), deserializedShardRange.getEnd());
+    }
+
+    private XContentParser createParser(String content) throws IOException {
+        return JsonXContent.jsonXContent.createParser(
+            NamedXContentRegistry.EMPTY,
+            LoggingDeprecationHandler.INSTANCE,
+            content
+        );
+    }
+
+    @Test
+    public void testParseValidShardRange() throws IOException {
+        String json = "{" +
+            "\"shard_id\": 1," +
+            "\"start\": 0," +
+            "\"end\": 100" +
+            "}";
+
+        XContentParser parser = createParser(json);
+        parser.nextToken(); // Move to start object
+
+        ShardRange shardRange = ShardRange.parse(parser);
+
+        assertEquals("Incorrect shard ID", 1, shardRange.getShardId());
+        assertEquals("Incorrect start value", 0, shardRange.getStart());
+        assertEquals("Incorrect end value", 100, shardRange.getEnd());
+    }
+
+    @Test
+    public void testParseEmptyObject() throws IOException {
+        String json = "{}";
+
+        XContentParser parser = createParser(json);
+        parser.nextToken();
+
+        ShardRange shardRange = ShardRange.parse(parser);
+
+        assertEquals("Empty object should have default shard ID", -1, shardRange.getShardId());
+        assertEquals("Empty object should have default start", -1, shardRange.getStart());
+        assertEquals("Empty object should have default end", -1, shardRange.getEnd());
+    }
+
+    @Test
+    public void testParseWithExtraFields() throws IOException {
+        String json = "{" +
+            "\"shard_id\": 1," +
+            "\"start\": 0," +
+            "\"end\": 100," +
+            "\"extra_field\": \"value\"" +
+            "}";
+
+        XContentParser parser = createParser(json);
+        parser.nextToken();
+
+        ShardRange shardRange = ShardRange.parse(parser);
+
+        assertEquals("Incorrect shard ID", 1, shardRange.getShardId());
+        assertEquals("Incorrect start value", 0, shardRange.getStart());
+        assertEquals("Incorrect end value", 100, shardRange.getEnd());
+    }
+
+}

--- a/server/src/test/java/org/opensearch/cluster/metadata/SplitShardsMetadataTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/SplitShardsMetadataTests.java
@@ -1,0 +1,805 @@
+package org.opensearch.cluster.metadata;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.*;
+
+import org.mockito.Mockito;
+import org.opensearch.common.collect.Tuple;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.test.OpenSearchTestCase;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
+
+public class SplitShardsMetadataTests extends OpenSearchTestCase {
+
+    @Test
+    public void testGetShardIdOfHashWithNoChildren() {
+        // Setup
+        SplitShardsMetadata.Builder builder = new SplitShardsMetadata.Builder(5);
+
+        // Test: When there are no children, should return the root shard id
+        int result = builder.build().getShardIdOfHash(0, 100, false);
+        assertEquals(0, result);
+    }
+
+    /**
+     * Tests getShardIdOfHash when there are existing child shards and in-progress children.
+     */
+    @Test
+    public void testGetShardIdOfHashWithExistingAndInProgressChildren() {
+        SplitShardsMetadata.Builder builder = new SplitShardsMetadata.Builder(1); // Start with 1 root shard
+        // First split - create existing child shards
+        builder.splitShard(0, 3);
+        builder.updateSplitMetadataForChildShards(0, Set.of(1, 2, 3));
+
+        // Second split - split the middle shard (ID 2)
+        builder.splitShard(2, 2);
+        SplitShardsMetadata metadata = builder.build();
+
+        // Execute - test hash that falls in the range of first child of shard 2
+        int result = metadata.getShardIdOfHash(0, 500, true);
+
+        // Assert - should route to the first child of the in-progress split
+        assertEquals("Hash should route to first child of in-progress split", 5, result);
+    }
+
+    /**
+     * Test getShardIdOfHash when root shard has no children but in-progress split exists
+     */
+    @Test
+    public void testGetShardIdOfHashWithInProgressSplit() {
+        SplitShardsMetadata.Builder builder = new SplitShardsMetadata.Builder(1); // Start with 1 root shard
+        // Setup - split root shard
+        builder.splitShard(0, 2);
+        SplitShardsMetadata metadata = builder.build();
+
+        // Execute - test with hash that should go to second child
+        int result = metadata.getShardIdOfHash(0, 100, true);
+
+        // Verify - should route to the second child shard
+        assertEquals("Should route to second child shard", 2, result);
+    }
+
+    @Test
+    public void testGetShardIdOfHashWithInProgressSplitIgnored() {
+        /**
+         * Test case for in-progress split being ignored
+         */
+        SplitShardsMetadata.Builder builder = new SplitShardsMetadata.Builder(5);
+        builder.splitShard(0, 2);
+        SplitShardsMetadata metadata = builder.build();
+
+        // Should return root shard ID when includeInProgressChildren is false
+        assertEquals(0, metadata.getShardIdOfHash(0, 100, false));
+    }
+
+    @Test
+    public void testGetShardIdOfHashWithInvalidHash() {
+        /**
+         * Test case for invalid hash value
+         */
+        SplitShardsMetadata metadata = new SplitShardsMetadata.Builder(5).build();
+        assertEquals(0, metadata.getShardIdOfHash(0, Integer.MIN_VALUE - 1, false));
+        assertEquals(0, metadata.getShardIdOfHash(0, Integer.MAX_VALUE + 1, false));
+    }
+
+    @Test
+    public void testGetShardIdOfHashWithInvalidRootShardId() {
+        /**
+         * Test case for invalid root shard ID
+         */
+        SplitShardsMetadata metadata = new SplitShardsMetadata.Builder(5).build();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> {
+            metadata.getShardIdOfHash(-1, 100, false);
+        });
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> {
+            metadata.getShardIdOfHash(5, 100, false);
+        });
+    }
+
+    @Test
+    public void testGetShardIdOfHashWithNonExistentShard() {
+        /**
+         * Test case for non-existent shard
+         */
+        SplitShardsMetadata.Builder builder = new SplitShardsMetadata.Builder(5);
+        builder.splitShard(0, 2);
+        SplitShardsMetadata metadata = builder.build();
+
+        // Attempt to get shard ID for a non-existent shard
+        assertEquals(1, metadata.getShardIdOfHash(1, 100, false));
+    }
+
+    /**
+     * Test case for getShardIdOfHash when the root shard has no children and no in-progress split
+     */
+    @Test
+    public void test_getShardIdOfHash_returnsRootShardId() {
+        // Arrange
+        int rootShardId = 0;
+        int hash = 123;
+        boolean includeInProgressChildren = false;
+
+        SplitShardsMetadata.Builder builder = new SplitShardsMetadata.Builder(1); // 1 root shard
+        SplitShardsMetadata metadata = builder.build();
+
+        // Act
+        int result = metadata.getShardIdOfHash(rootShardId, hash, includeInProgressChildren);
+
+        // Assert
+        assertEquals("Should return the root shard ID when there are no children", rootShardId, result);
+    }
+
+    /**
+     * Test getShardIdOfHash when root shard has children but no in-progress splits
+     */
+    @Test
+    public void test_getShardIdOfHash_withExistingChildren() {
+        // Setup
+        int rootShardId = 0;
+        int hash = 500;
+        boolean includeInProgressChildren = true;
+
+        // Setup
+        SplitShardsMetadata.Builder builder = new SplitShardsMetadata.Builder(1); // Start with 1 root shard
+
+        // Split the root shard into 3 pieces
+        builder.splitShard(0, 3);
+
+        // Complete the split with three child shards
+        Set<Integer> childShardIds = Set.of(1, 2, 3);
+        builder.updateSplitMetadataForChildShards(0, childShardIds);
+
+        SplitShardsMetadata metadata = builder.build();
+
+        // Execute
+        int result = metadata.getShardIdOfHash(rootShardId, hash, includeInProgressChildren);
+
+        // Verify
+        assertEquals(2, result);
+    }
+
+    /**
+     * Test that getNumberOfRootShards returns the correct number of root shards
+     */
+    @Test
+    public void testGetNumberOfRootShardsReturnsCorrectCount() {
+        // Arrange
+        int expectedRootShards = 5;
+        SplitShardsMetadata.Builder builder = new SplitShardsMetadata.Builder(expectedRootShards);
+        SplitShardsMetadata metadata = builder.build();
+
+        // Act
+        int actualRootShards = metadata.getNumberOfRootShards();
+
+        // Assert
+        assertEquals("Number of root shards should match the initial count", expectedRootShards, actualRootShards);
+    }
+
+
+    @Test
+    public void testGetNumberOfRootShardsAfterSplitting() {
+        /**
+         * Test case for getting number of root shards after splitting
+         * Expected behavior: Should return the original number of root shards
+         */
+        SplitShardsMetadata.Builder builder = new SplitShardsMetadata.Builder(5);
+        builder.splitShard(0, 2);
+        SplitShardsMetadata metadata = builder.build();
+        assertEquals("Number of root shards should remain unchanged after splitting", 5, metadata.getNumberOfRootShards());
+    }
+
+    @Test
+    public void testGetNumberOfRootShardsWithEmptyMetadata() {
+        /**
+         * Test case for empty metadata
+         * Expected behavior: Should return 0 for empty metadata
+         */
+        SplitShardsMetadata emptyMetadata = new SplitShardsMetadata.Builder(0).build();
+        assertEquals("Empty metadata should have 0 root shards", 0, emptyMetadata.getNumberOfRootShards());
+    }
+
+    /**
+     * This test verifies that the getNumberOfShards() method
+     * correctly returns maxShardId + 1
+     */
+    @Test
+    public void testGetNumberOfShardsReturnsMaxShardIdPlusOne() {
+        // Arrange
+        int maxShardId = 5;
+        SplitShardsMetadata metadata = new SplitShardsMetadata.Builder(maxShardId + 1).build();
+
+        // Act
+        int result = metadata.getNumberOfShards();
+
+        // Assert
+        assertEquals("getNumberOfShards should return maxShardId + 1", maxShardId + 1, result);
+    }
+
+    public void testGetNumberOfShardsAfterSplitting() {
+        /**
+         * Test case for getting number of shards after splitting
+         */
+        SplitShardsMetadata.Builder builder = new SplitShardsMetadata.Builder(1);
+        // Split the root shard into 3 pieces
+        builder.splitShard(0, 3);
+
+        // Complete the split with three child shards
+        Set<Integer> childShardIds = Set.of(1, 2, 3);
+        builder.updateSplitMetadataForChildShards(0, childShardIds);
+        SplitShardsMetadata metadata = builder.build();
+        assertEquals(4, metadata.getNumberOfShards());
+    }
+
+    @Test
+    public void testGetNumberOfShardsWithEmptyMetadata() {
+        /**
+         * Test case for empty metadata
+         * Expected behavior: Should return 0 for empty metadata
+         */
+        SplitShardsMetadata emptyMetadata = new SplitShardsMetadata.Builder(0).build();
+        assertEquals("Empty metadata should have 0 shards", 0, emptyMetadata.getNumberOfShards());
+    }
+
+    /**
+     * Test case for getChildShardsOfParent when the parent shard has child shards
+     */
+    @Test
+    public void testGetChildShardsOfParentWithExistingChildren() {
+        // Create a builder and add some child shards for a parent
+        SplitShardsMetadata.Builder builder = new SplitShardsMetadata.Builder(5);
+        int parentShardId = 2;
+        int numberOfChildren = 3;
+        builder.splitShard(parentShardId, numberOfChildren);
+
+        // Build the metadata
+        SplitShardsMetadata metadata = builder.build();
+
+        // Get child shards of the parent
+        ShardRange[] childShards = metadata.getChildShardsOfParent(parentShardId);
+
+        // Assert that child shards are returned and match the expected number
+        assertNotNull(childShards);
+        assertEquals(numberOfChildren, childShards.length);
+
+        // Verify that each child shard is a copy and not the original
+        ShardRange[] originalChildShards = metadata.getChildShardsOfParent(parentShardId);
+        for (int i = 0; i < childShards.length; i++) {
+            assertNotSame(originalChildShards[i], childShards[i]);
+            assertEquals(originalChildShards[i], childShards[i]);
+        }
+    }
+
+    @Test
+    public void testGetChildShardsOfParentAfterCancelledSplit() {
+        /**
+         * Test case for getChildShardsOfParent after a cancelled split operation
+         */
+        SplitShardsMetadata.Builder builder = new SplitShardsMetadata.Builder(5);
+        builder.splitShard(0, 2);
+        builder.cancelSplit(0);
+        SplitShardsMetadata metadata = builder.build();
+
+        assertNull("Should return null for shard with cancelled split", metadata.getChildShardsOfParent(0));
+    }
+
+    @Test
+    public void testGetChildShardsOfParentWithNonExistentShardId() {
+        /**
+         * Test case for getChildShardsOfParent with a non-existent shard ID
+         */
+        SplitShardsMetadata.Builder builder = new SplitShardsMetadata.Builder(5);
+        SplitShardsMetadata metadata = builder.build();
+
+        assertNull("Should return null for non-existent shard ID", metadata.getChildShardsOfParent(10));
+    }
+
+    @Test
+    public void testGetChildShardsOfParentWithUnsplitShard() {
+        /**
+         * Test case for getChildShardsOfParent with an unsplit shard
+         */
+        SplitShardsMetadata.Builder builder = new SplitShardsMetadata.Builder(5);
+        SplitShardsMetadata metadata = builder.build();
+
+        assertNull("Should return null for unsplit shard", metadata.getChildShardsOfParent(0));
+    }
+
+//    /**
+//     * Tests numberOfEmptyParentShards() when a split is in progress
+//     */
+//    @Test
+//    public void testNumberOfEmptyParentShardsWithInProgressSplit() {
+//        // Create a builder with 3 root shards
+//        SplitShardsMetadata.Builder builder = new SplitShardsMetadata.Builder(3);
+//
+//        // Split shard 0 into 2 children
+////        builder.splitShard(0, 2);
+//
+//        // Build the metadata
+//        SplitShardsMetadata metadata = builder.build();
+//
+//        // Assert that there's one empty parent shard (shard 1)
+//        // Shard 0 is in progress, so it's not counted as empty
+//        assertEquals(2, metadata.numberOfEmptyParentShards());
+//    }
+
+    /**
+     * Test case for SplitShardsMetadata.Builder constructor with numberOfShards parameter
+     */
+    @Test
+    public void testBuilderConstructorWithNumberOfShards() {
+        int numberOfShards = 5;
+        SplitShardsMetadata.Builder builder = new SplitShardsMetadata.Builder(numberOfShards);
+
+        SplitShardsMetadata metadata = builder.build();
+
+        assertEquals(numberOfShards, metadata.getNumberOfRootShards());
+        assertEquals(numberOfShards, metadata.getNumberOfShards());
+        assertEquals(SplitShardsMetadata.SPLIT_NOT_IN_PROGRESS, metadata.getInProgressSplitShardId());
+
+        for (int i = 0; i < numberOfShards; i++) {
+            assertNull(metadata.getChildShardsOfParent(i));
+        }
+    }
+
+    /**
+     * Tests the Builder constructor with a SplitShardsMetadata instance where some root shards have no children.
+     */
+    @Test
+    public void testBuilderWithEmptyRootShards() {
+        // Create a SplitShardsMetadata with some empty root shards
+        SplitShardsMetadata.Builder originalBuilder = new SplitShardsMetadata.Builder(3);
+        SplitShardsMetadata original = originalBuilder.build();
+
+        // Create a new Builder using the original SplitShardsMetadata
+        SplitShardsMetadata.Builder newBuilder = new SplitShardsMetadata.Builder(original);
+
+        // Build the new SplitShardsMetadata
+        SplitShardsMetadata result = newBuilder.build();
+
+        // Assert that the new SplitShardsMetadata matches the original
+        assertEquals(original, result);
+        assertEquals(3, result.getNumberOfRootShards());
+        assertNull(result.getChildShardsOfParent(0));
+        assertNull(result.getChildShardsOfParent(1));
+        assertNull(result.getChildShardsOfParent(2));
+        assertEquals(SplitShardsMetadata.SPLIT_NOT_IN_PROGRESS, result.getInProgressSplitShardId());
+    }
+
+    /**
+     * Test that cancelSplit correctly removes the in-progress split and resets the inProgressSplitShardId
+     */
+    @Test
+    public void testCancelSplitRemovesInProgressSplit() {
+        // Setup
+        int numberOfShards = 5;
+        int sourceShardId = 2;
+        int numberOfChildren = 2;
+        SplitShardsMetadata.Builder builder = new SplitShardsMetadata.Builder(numberOfShards);
+
+        // Start a split
+        builder.splitShard(sourceShardId, numberOfChildren);
+
+        // Verify split is in progress
+        assertEquals(sourceShardId, builder.build().getInProgressSplitShardId());
+
+        // Cancel the split
+        builder.cancelSplit(sourceShardId);
+
+        // Build the metadata
+        SplitShardsMetadata metadata = builder.build();
+
+        // Verify the split was canceled
+        assertEquals(SplitShardsMetadata.SPLIT_NOT_IN_PROGRESS, metadata.getInProgressSplitShardId());
+        assertNull(metadata.getChildShardsOfParent(sourceShardId));
+    }
+
+    @Test
+    public void testCancelSplitWhenNoSplitInProgress() {
+        SplitShardsMetadata.Builder builder = new SplitShardsMetadata.Builder(1);
+        assertThrows(AssertionError.class, () -> {
+            builder.cancelSplit(0);
+        });
+    }
+
+    @Test
+    public void testCancelSplitMultipleTimes() {
+        SplitShardsMetadata.Builder builder = new SplitShardsMetadata.Builder(1);
+        builder.splitShard(0, 2);
+        builder.cancelSplit(0);
+        assertThrows(AssertionError.class, () -> {
+            builder.cancelSplit(0);
+        });
+    }
+
+//    @Test
+//    public void testCancelSplitWhenSplitInProgress() {
+//        SplitShardsMetadata.Builder builder = new SplitShardsMetadata.Builder(2);
+//        // Start a split
+//        builder.splitShard(1,2);
+//        builder.cancelSplit(0);
+//    }
+
+    /**
+     * Test that getInProgressSplitShardId returns the correct shard ID
+     */
+    @Test
+    public void testGetInProgressSplitShardId() {
+        int expectedShardId = 5;
+        SplitShardsMetadata.Builder builder = new SplitShardsMetadata.Builder(10);
+        builder.splitShard(expectedShardId, 2);
+        SplitShardsMetadata metadata = builder.build();
+
+        int actualShardId = metadata.getInProgressSplitShardId();
+
+        assertEquals("The in-progress split shard ID should match the expected value", expectedShardId, actualShardId);
+    }
+
+    @Test
+    public void testGetInProgressSplitShardIdAfterCancelingSplit() {
+        SplitShardsMetadata.Builder builder = new SplitShardsMetadata.Builder(1);
+        builder.splitShard(0, 2);
+        builder.cancelSplit(0);
+        SplitShardsMetadata metadata = builder.build();
+        assertEquals("After canceling a split, SPLIT_NOT_IN_PROGRESS should be returned", SplitShardsMetadata.SPLIT_NOT_IN_PROGRESS, metadata.getInProgressSplitShardId());
+    }
+
+    @Test
+    public void testGetInProgressSplitShardIdAfterCompletingSplit() {
+        SplitShardsMetadata.Builder builder = new SplitShardsMetadata.Builder(1);
+        builder.splitShard(0, 2);
+        builder.updateSplitMetadataForChildShards(0, Set.of(1, 2));
+        SplitShardsMetadata metadata = builder.build();
+        assertEquals("After completing a split, SPLIT_NOT_IN_PROGRESS should be returned", SplitShardsMetadata.SPLIT_NOT_IN_PROGRESS, metadata.getInProgressSplitShardId());
+    }
+
+    @Test
+    public void testGetInProgressSplitShardIdWhenNoSplitInProgress() {
+        SplitShardsMetadata metadata = new SplitShardsMetadata.Builder(1).build();
+        assertEquals("When no split is in progress, SPLIT_NOT_IN_PROGRESS should be returned", SplitShardsMetadata.SPLIT_NOT_IN_PROGRESS, metadata.getInProgressSplitShardId());
+    }
+
+    @Test
+    public void testGetInProgressSplitShardIdWithValidSplitInProgress() {
+        SplitShardsMetadata.Builder builder = new SplitShardsMetadata.Builder(1);
+        builder.splitShard(0, 2);
+        SplitShardsMetadata metadata = builder.build();
+        assertEquals("When a valid split is in progress, the correct shard ID should be returned", 0, metadata.getInProgressSplitShardId());
+    }
+
+    @Test
+    public void testIsSplitOfShardInProgress_CorrectShardInProgress() {
+        /**
+         * Test that the method returns true when the correct shard is being split.
+         */
+        SplitShardsMetadata.Builder builder = new SplitShardsMetadata.Builder(5);
+        builder.splitShard(2, 2);
+        SplitShardsMetadata metadata = builder.build();
+        assertTrue(metadata.isSplitOfShardInProgress(2));
+    }
+
+    @Test
+    public void testIsSplitOfShardInProgress_DifferentShardInProgress() {
+        /**
+         * Test that the method returns false when a different shard is being split.
+         */
+        SplitShardsMetadata.Builder builder = new SplitShardsMetadata.Builder(5);
+        builder.splitShard(2, 2);
+        SplitShardsMetadata metadata = builder.build();
+        assertFalse(metadata.isSplitOfShardInProgress(1));
+    }
+
+    @Test
+    public void testIsSplitOfShardInProgress_NoSplitInProgress() {
+        /**
+         * Test that the method returns false when no split is in progress.
+         */
+        SplitShardsMetadata metadata = new SplitShardsMetadata.Builder(5).build();
+        assertFalse(metadata.isSplitOfShardInProgress(0));
+        assertTrue(metadata.isSplitOfShardInProgress(SplitShardsMetadata.SPLIT_NOT_IN_PROGRESS));
+    }
+
+    @Test
+    public void testSplitShardWhenSplitAlreadyInProgress() {
+        SplitShardsMetadata.Builder builder = new SplitShardsMetadata.Builder(2);
+        builder.splitShard(0, 2);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            builder.splitShard(1, 2);
+        });
+        assertTrue(exception.getMessage().contains("Split of shard [0] is already in progress or completed."));
+    }
+
+    @Test
+    public void testSplitShardWithCompletedSplit() {
+        SplitShardsMetadata.Builder builder = new SplitShardsMetadata.Builder(5);
+        builder.splitShard(0, 2);
+        builder.updateSplitMetadataForChildShards(0, Set.of(5, 6));
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            builder.splitShard(0, 2);
+        });
+        assertTrue(exception.getMessage().startsWith("Split of shard [-2] is already in progress or completed."));
+    }
+
+    @Test
+    public void testSplitShardWithInvalidNumberOfChildren() {
+        SplitShardsMetadata.Builder builder = new SplitShardsMetadata.Builder(1);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            builder.splitShard(0, 10000000);
+        });
+        assertTrue(exception.getMessage().contains("Cannot split shard [0] further."));
+    }
+
+    @Test
+    public void testSplitShardWithInvalidChildren() {
+        SplitShardsMetadata.Builder builder = new SplitShardsMetadata.Builder(1);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            builder.splitShard(0, 1000000);
+        });
+        assertTrue(exception.getMessage().contains(" is below shard range threshold of "));
+    }
+
+    @Test
+    public void testSplitInvalidShardId() {
+        SplitShardsMetadata.Builder builder = new SplitShardsMetadata.Builder(1);
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> builder.splitShard(10, 2) // Invalid shard ID
+        );
+        assertTrue(exception.getMessage().contains("Shard ID doesn't exist in the current list of shard ranges"));
+    }
+
+    @Test
+    public void testSplitShardBasicOperation() {
+        SplitShardsMetadata.Builder builder = new SplitShardsMetadata.Builder(1);
+        // Test basic split operation
+        builder.splitShard(0, 2);
+        SplitShardsMetadata metadata = builder.build();
+
+        // Verify split state
+        assertEquals(0, metadata.getInProgressSplitShardId());
+        ShardRange[] childShards = metadata.getChildShardsOfParent(0);
+        assertNotNull(childShards);
+        assertEquals(2, childShards.length);
+
+        // Verify shard ranges
+        assertTrue(childShards[0].getEnd() < childShards[1].getStart());
+        assertEquals(childShards[0].getEnd() + 1, childShards[1].getStart());
+    }
+
+    @Test
+    public void testSplitShardNestedSplit() {
+        SplitShardsMetadata.Builder builder = new SplitShardsMetadata.Builder(1); // Start with 1 root shard
+
+        // First split - split root shard 0 into two children (shards 1 and 2)
+        builder.splitShard(0, 2);
+        builder.updateSplitMetadataForChildShards(0, Set.of(1, 2));
+
+        // Verify first split
+        SplitShardsMetadata metadata = builder.build();
+        ShardRange[] firstLevelShards = metadata.getChildShardsOfParent(0);
+        assertNotNull("First level split should create child shards", firstLevelShards);
+        assertEquals("Should have 2 child shards", 2, firstLevelShards.length);
+
+        // Second split - split first child shard (shard 1) into three children
+        builder.splitShard(1, 3);
+        builder.updateSplitMetadataForChildShards(1, Set.of(3, 4, 5));
+
+        // Get final metadata
+        metadata = builder.build();
+
+        // Verify the nested split results
+        ShardRange[] secondLevelShards = metadata.getChildShardsOfParent(1);
+        assertNotNull("Second level split should create child shards", secondLevelShards);
+        assertEquals("Should have 3 child shards", 3, secondLevelShards.length);
+
+//         Verify shard hierarchy
+        assertTrue("Original shard 0 should be split", metadata.isEmptyParentShard(0));
+        assertTrue("Child shard 1 should be split", metadata.isEmptyParentShard(1));
+        assertFalse("Child shard 2 should not be split", metadata.isEmptyParentShard(2));
+
+        // Verify ranges are properly distributed
+        for (int i = 0; i < secondLevelShards.length - 1; i++) {
+            assertTrue("Shard ranges should be in order",
+                secondLevelShards[i].getEnd() < secondLevelShards[i + 1].getStart());
+            assertEquals("Shard ranges should be contiguous",
+                secondLevelShards[i].getEnd() + 1, secondLevelShards[i + 1].getStart());
+        }
+
+        // Verify range boundaries
+        ShardRange parentRange = firstLevelShards[0]; // Range of shard 1
+        assertEquals("First child should start at parent's start",
+            parentRange.getStart(), secondLevelShards[0].getStart());
+        assertEquals("Last child should end at parent's end",
+            parentRange.getEnd(), secondLevelShards[secondLevelShards.length - 1].getEnd());
+
+        // Test hash routing through the nested structure
+        int hashInFirstThird = parentRange.getStart() +
+            (parentRange.getEnd() - parentRange.getStart()) / 3;
+
+        assertEquals("Hash should route to first child of nested split",
+            3, metadata.getShardIdOfHash(0, hashInFirstThird, true));
+    }
+
+    @Test
+    public void testUpdateSplitMetadataWithInvalidSourceShardId() {
+        SplitShardsMetadata.Builder builder = new SplitShardsMetadata.Builder(1);
+        Set<Integer> newChildShardIds = new HashSet<>();
+        newChildShardIds.add(1);
+        newChildShardIds.add(2);
+        assertThrows(IllegalArgumentException.class, () -> {
+            builder.updateSplitMetadataForChildShards(1, newChildShardIds);
+        });
+    }
+
+//    @Test
+//    public void testUpdateSplitMetadataForChildShards_NoSplitInProgress() {
+//        SplitShardsMetadata.Builder builder = new SplitShardsMetadata.Builder(1);
+//        builder.splitShard(0, 2);
+//        builder.cancelSplit(0);
+//        builder.updateSplitMetadataForChildShards(0, Set.of(1, 2));
+
+//        assertThrows(AssertionError.class, () -> {
+//            builder.updateSplitMetadataForChildShards(0, newChildShardIds);
+//        });
+//    }
+
+    @Test
+    public void testUpdateSplitMetadataForChildShards_InvalidChildShardId() {
+        SplitShardsMetadata.Builder builder = new SplitShardsMetadata.Builder(5);
+        builder.splitShard(0, 2);
+        Set<Integer> newChildShardIds = new HashSet<>();
+        newChildShardIds.add(5);
+        newChildShardIds.add(7);
+
+        assertThrows(AssertionError.class, () -> {
+            builder.updateSplitMetadataForChildShards(0, newChildShardIds);
+        });
+    }
+
+    @Test
+    public void testUpdateSplitMetadataForChildShards_MismatchedChildShardCount() {
+        SplitShardsMetadata.Builder builder = new SplitShardsMetadata.Builder(5);
+        builder.splitShard(0, 2);
+        Set<Integer> newChildShardIds = new HashSet<>();
+        newChildShardIds.add(5);
+
+        assertThrows(AssertionError.class, () -> {
+            builder.updateSplitMetadataForChildShards(0, newChildShardIds);
+        });
+    }
+
+    @Test
+    public void testUpdateSplitMetadataForChildShards_EmptyNewChildShardIds() {
+        SplitShardsMetadata.Builder builder = new SplitShardsMetadata.Builder(5);
+        builder.splitShard(0, 2);
+        Set<Integer> newChildShardIds = new HashSet<>();
+
+        assertThrows(AssertionError.class, () -> {
+            builder.updateSplitMetadataForChildShards(0, newChildShardIds);
+        });
+    }
+
+    /**
+     * Test case for updateSplitMetadataForChildShards method
+     * Verifies that the method correctly updates the metadata for child shards
+     */
+    @Test
+    public void testUpdateSplitMetadataForChildShards_Success() {
+        // Arrange
+        SplitShardsMetadata.Builder builder = new SplitShardsMetadata.Builder(2);
+        int sourceShardId = 0;
+        builder.splitShard(sourceShardId, 2);
+        Set<Integer> newChildShardIds = new HashSet<>(Arrays.asList(2, 3));
+
+        // Act
+        builder.updateSplitMetadataForChildShards(sourceShardId, newChildShardIds);
+        SplitShardsMetadata metadata = builder.build();
+
+        // Assert
+        assertEquals(SplitShardsMetadata.SPLIT_NOT_IN_PROGRESS, metadata.getInProgressSplitShardId());
+        assertEquals(4, metadata.getNumberOfShards());
+
+        ShardRange[] childShards = metadata.getChildShardsOfParent(sourceShardId);
+        assertNotNull(childShards);
+        assertEquals(2, childShards.length);
+        assertTrue(newChildShardIds.contains(childShards[0].getShardId()));
+        assertTrue(newChildShardIds.contains(childShards[1].getShardId()));
+
+    }
+
+    @Test
+    public void testReadDiffFromWithEmptyInput() throws IOException {
+        StreamInput emptyInput = Mockito.mock(StreamInput.class);
+        when(emptyInput.available()).thenReturn(0);
+        assertNotNull(SplitShardsMetadata.readDiffFrom(emptyInput));
+    }
+
+    @Test
+    public void testEqualsMethod() {
+        // Test 1: Same object reference
+        SplitShardsMetadata metadata = new SplitShardsMetadata.Builder(1).build();
+        assertTrue("Same object should be equal to itself", metadata.equals(metadata));
+
+        // Test 2: Null comparison
+        assertFalse("Object should not be equal to null", metadata.equals(null));
+
+        // Test 3: Different class
+        assertFalse("Should not be equal to different class",
+            metadata.equals(new Object()));
+
+        // Test 4: Equal objects
+        SplitShardsMetadata metadata1 = new SplitShardsMetadata.Builder(2).build();
+        SplitShardsMetadata metadata2 = new SplitShardsMetadata.Builder(2).build();
+        assertTrue("Two equivalent objects should be equal", metadata1.equals(metadata2));
+
+        // Test 5: Different maxShardId
+        SplitShardsMetadata differentMaxShardId = new SplitShardsMetadata.Builder(3).build();
+        assertFalse("Objects with different maxShardId should not be equal",
+            metadata1.equals(differentMaxShardId));
+
+        // Test 6: Different inProgressSplitShardId
+        SplitShardsMetadata.Builder builder1 = new SplitShardsMetadata.Builder(2);
+        builder1.splitShard(0, 2);  // This will set inProgressSplitShardId
+        SplitShardsMetadata withSplit = builder1.build();
+        assertFalse("Objects with different inProgressSplitShardId should not be equal",
+            metadata1.equals(withSplit));
+
+        // Test 7: Different rootShardsToAllChildren
+        SplitShardsMetadata.Builder builder2 = new SplitShardsMetadata.Builder(2);
+        builder2.splitShard(0, 2);
+        builder2.updateSplitMetadataForChildShards(0, Set.of(2, 3));
+        SplitShardsMetadata withDifferentRootShards = builder2.build();
+        assertFalse("Objects with different rootShardsToAllChildren should not be equal",
+            metadata1.equals(withDifferentRootShards));
+
+        // Test 8: Different parentToChildShards
+        SplitShardsMetadata.Builder builder3 = new SplitShardsMetadata.Builder(2);
+        builder3.splitShard(1, 2);  // Split different shard
+        builder3.updateSplitMetadataForChildShards(1, Set.of(2, 3));
+        SplitShardsMetadata withDifferentParentToChild = builder3.build();
+        assertFalse("Objects with different parentToChildShards should not be equal",
+            withDifferentRootShards.equals(withDifferentParentToChild));
+
+        // Test 9: Symmetric equality
+        assertTrue("Equality should be symmetric",
+            metadata1.equals(metadata2) && metadata2.equals(metadata1));
+
+        // Test 10: Transitive equality
+        SplitShardsMetadata metadata3 = new SplitShardsMetadata.Builder(2).build();
+        assertTrue("Equality should be transitive",
+            metadata1.equals(metadata2) && metadata2.equals(metadata3) && metadata1.equals(metadata3));
+    }
+
+    @Test
+    public void testEqualsWithNullArrayElements() {
+        // Create metadata with null elements in rootShardsToAllChildren
+        SplitShardsMetadata.Builder builder1 = new SplitShardsMetadata.Builder(3);
+        SplitShardsMetadata metadata1 = builder1.build();
+
+        SplitShardsMetadata.Builder builder2 = new SplitShardsMetadata.Builder(3);
+        SplitShardsMetadata metadata2 = builder2.build();
+
+        assertTrue("Objects with null array elements should be equal if structure is same",
+            metadata1.equals(metadata2));
+    }
+
+    @Test
+    public void testEqualsWithEmptyMaps() {
+        // Create metadata with empty parentToChildShards maps
+        SplitShardsMetadata.Builder builder1 = new SplitShardsMetadata.Builder(1);
+        SplitShardsMetadata metadata1 = builder1.build();
+
+        SplitShardsMetadata.Builder builder2 = new SplitShardsMetadata.Builder(1);
+        SplitShardsMetadata metadata2 = builder2.build();
+
+        assertTrue("Objects with empty maps should be equal if structure is same",
+            metadata1.equals(metadata2));
+    }
+
+
+
+}

--- a/server/src/test/java/org/opensearch/cluster/routing/IndexShardRoutingTableTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/IndexShardRoutingTableTests.java
@@ -32,17 +32,19 @@
 
 package org.opensearch.cluster.routing;
 
+import org.junit.Test;
+import org.opensearch.cluster.metadata.ShardRange;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.core.common.io.stream.BufferedChecksumStreamOutput;
 import org.opensearch.core.index.Index;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.cluster.routing.AllocationId;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
+
+import static org.mockito.Mockito.*;
 
 public class IndexShardRoutingTableTests extends OpenSearchTestCase {
     public void testEqualsAttributesKey() {
@@ -142,4 +144,115 @@ public class IndexShardRoutingTableTests extends OpenSearchTestCase {
             table.shardsMatchingPredicate(shardRouting -> !shardRouting.primary() && shardRouting.relocating())
         );
     }
+    /**
+     *
+     * Testing various shard states and conditions
+     */
+    public void test_IndexShardRoutingTable_withVariousShardStates() {
+        ShardId shardId = new ShardId(new Index("test", "uuid"), 0);
+        ShardId shardId2 = new ShardId(new Index("test", "uuid"), 1);
+
+        // Create shards with different states and conditions
+        ShardRouting primaryShard = TestShardRouting.newShardRouting(shardId, "node1", true, ShardRoutingState.INITIALIZING);
+        ShardRouting relocatingShard = TestShardRouting.newShardRouting(shardId2, "node2", "node3", false, ShardRoutingState.RELOCATING);
+
+        // Arrange
+        ShardId parentShardId = new ShardId("test_index", "_na_", 2);
+        ShardRouting parentShard = TestShardRouting.newShardRouting(parentShardId, "node1", false, ShardRoutingState.SPLITTING);
+
+        // Create child shards
+        ShardId childShardId1 = new ShardId("test_index", "_na_", 3);
+        ShardId childShardId2 = new ShardId("test_index", "_na_", 4);
+        ShardRouting childShard1 = TestShardRouting.newShardRouting(childShardId1, "node1", false, ShardRoutingState.INITIALIZING);
+        ShardRouting childShard2 = TestShardRouting.newShardRouting(childShardId2, "node1", false, ShardRoutingState.INITIALIZING);
+
+        // Create a splitting shard
+        ShardRouting splittingShard = new ShardRouting(
+            parentShardId,
+            parentShard.currentNodeId(),
+            null,
+            parentShard.primary(),
+            parentShard.isSearchOnly(),
+            ShardRoutingState.SPLITTING,
+            parentShard.recoverySource(),
+            parentShard.unassignedInfo(),
+            parentShard.allocationId(),
+            1000L,
+            new ShardRouting[]{childShard1, childShard2},
+            null
+        );
+
+        List<ShardRouting> shards = Arrays.asList(primaryShard, relocatingShard, splittingShard);
+
+        // Create IndexShardRoutingTable
+        IndexShardRoutingTable table = new IndexShardRoutingTable(shardId, shards);
+
+        // Verify the state of the created table
+        assertEquals(shardId, table.shardId());
+        assertEquals(3, table.size());
+        assertEquals(primaryShard, table.primaryShard());
+        assertTrue(table.primaryShard().primary());
+        assertFalse(table.primaryShard().active());
+        assertTrue(table.primaryShard().initializing());
+
+        List<ShardRouting> allInitializingShards = table.getAllInitializingShards();
+        assertEquals(4, allInitializingShards.size());
+        assertTrue(allInitializingShards.contains(primaryShard));
+        assertTrue(allInitializingShards.contains(relocatingShard.getTargetRelocatingShard()));
+
+        List<ShardRouting> assignedShards = table.assignedShards();
+        assertEquals(6, assignedShards.size());
+        assertTrue(assignedShards.containsAll(shards));
+
+        assertFalse(table.allShardsStarted());
+    }
+
+    /**
+     * Test case for a primary shard that is active, initializing, search-only, relocating, and assigned to a node,
+     * but not splitting and not in STARTED state.
+     */
+    public void test_IndexShardRoutingTable_9() {
+        ShardId shardId = new ShardId(new Index("test", "_na_"), 0);
+
+        // Create a primary shard that meets all the specified conditions
+        ShardRouting primaryShard = TestShardRouting.newShardRouting(shardId, "sourceNode", "targetNode", true, ShardRoutingState.RELOCATING);
+
+        List<ShardRouting> shards = Collections.singletonList(primaryShard);
+
+        IndexShardRoutingTable table = new IndexShardRoutingTable(shardId, shards);
+
+        // Verify the properties of the created IndexShardRoutingTable
+        assertEquals(shardId, table.shardId());
+        assertEquals(1, table.size());
+        assertEquals(primaryShard, table.primaryShard());
+
+        // Verify shard properties
+        assertTrue(table.primaryShard().primary());
+        assertTrue(table.primaryShard().active());
+        assertFalse(table.primaryShard().initializing()); // Relocating shards are not considered initializing
+        assertFalse(table.primaryShard().isSearchOnly());
+        assertTrue(table.primaryShard().relocating());
+        assertTrue(table.primaryShard().assignedToNode());
+        assertFalse(table.primaryShard().splitting());
+        assertNotEquals(ShardRoutingState.STARTED, table.primaryShard().state());
+
+        // Verify other table properties
+        assertEquals(1, table.activeShards().size());
+        assertEquals(2, table.assignedShards().size());
+        assertEquals(1, table.getAllInitializingShards().size());
+        assertFalse(table.allShardsStarted());
+
+        // Verify allocation IDs
+        assertTrue(table.getAllAllocationIds().contains(primaryShard.allocationId().getId()));
+        assertEquals(2, table.getAllAllocationIds().size()); // Source and target allocation IDs
+
+        // Verify relocating shard properties
+        ShardRouting targetShard = table.getByAllocationId(primaryShard.getTargetRelocatingShard().allocationId().getId());
+        assertNotNull(targetShard);
+        assertEquals(ShardRoutingState.INITIALIZING, targetShard.state());
+        assertEquals(primaryShard.getTargetRelocatingShard().allocationId(), targetShard.allocationId());
+        assertEquals("targetNode", targetShard.currentNodeId());
+    }
 }
+
+

--- a/server/src/test/java/org/opensearch/cluster/routing/RoutingNodeTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/RoutingNodeTests.java
@@ -60,6 +60,7 @@ public class RoutingNodeTests extends OpenSearchTestCase {
         false,
         ShardRoutingState.RELOCATING
     );
+    private ShardRouting splittingShard0 = TestShardRouting.newShardRouting("test", 3, "node-1", false, ShardRoutingState.SPLITTING);
     private RoutingNode routingNode;
 
     @Override
@@ -68,29 +69,32 @@ public class RoutingNodeTests extends OpenSearchTestCase {
         InetAddress inetAddress = InetAddress.getByAddress("name1", new byte[] { (byte) 192, (byte) 168, (byte) 0, (byte) 1 });
         TransportAddress transportAddress = new TransportAddress(inetAddress, randomIntBetween(0, 65535));
         DiscoveryNode discoveryNode = new DiscoveryNode("name1", "node-1", transportAddress, emptyMap(), emptySet(), Version.CURRENT);
-        routingNode = new RoutingNode("node1", discoveryNode, unassignedShard0, initializingShard0, relocatingShard0);
+        routingNode = new RoutingNode("node1", discoveryNode, unassignedShard0, initializingShard0, relocatingShard0, splittingShard0);
     }
 
     public void testAdd() {
-        ShardRouting initializingShard1 = TestShardRouting.newShardRouting("test", 3, "node-1", false, ShardRoutingState.INITIALIZING);
+        ShardRouting initializingShard1 = TestShardRouting.newShardRouting("test", 4, "node-1", false, ShardRoutingState.INITIALIZING);
         ShardRouting relocatingShard0 = TestShardRouting.newShardRouting(
             "test",
-            4,
+            5,
             "node-1",
             "node-2",
             false,
             ShardRoutingState.RELOCATING
         );
+        ShardRouting splittingShard = TestShardRouting.newShardRouting("test", 6, "node-1", false, ShardRoutingState.SPLITTING);
         routingNode.add(initializingShard1);
         routingNode.add(relocatingShard0);
-        assertThat(routingNode.getByShardId(new ShardId("test", IndexMetadata.INDEX_UUID_NA_VALUE, 3)), equalTo(initializingShard1));
-        assertThat(routingNode.getByShardId(new ShardId("test", IndexMetadata.INDEX_UUID_NA_VALUE, 4)), equalTo(relocatingShard0));
+        routingNode.add(splittingShard);
+        assertThat(routingNode.getByShardId(new ShardId("test", IndexMetadata.INDEX_UUID_NA_VALUE, 4)), equalTo(initializingShard1));
+        assertThat(routingNode.getByShardId(new ShardId("test", IndexMetadata.INDEX_UUID_NA_VALUE, 5)), equalTo(relocatingShard0));
+        assertThat(routingNode.getByShardId(new ShardId("test", IndexMetadata.INDEX_UUID_NA_VALUE, 6)), equalTo(splittingShard));
     }
 
     public void testPrimaryFirstIterator() {
-        ShardRouting initializingShard3 = TestShardRouting.newShardRouting("test", 3, "node-1", false, ShardRoutingState.INITIALIZING);
-        ShardRouting relocatingShard4 = TestShardRouting.newShardRouting("test", 4, "node-1", "node-2", true, ShardRoutingState.RELOCATING);
-        ShardRouting initializingShard5 = TestShardRouting.newShardRouting("test", 5, "node-1", true, ShardRoutingState.INITIALIZING);
+        ShardRouting initializingShard3 = TestShardRouting.newShardRouting("test", 4, "node-1", false, ShardRoutingState.INITIALIZING);
+        ShardRouting relocatingShard4 = TestShardRouting.newShardRouting("test", 5, "node-1", "node-2", true, ShardRoutingState.RELOCATING);
+        ShardRouting initializingShard5 = TestShardRouting.newShardRouting("test", 6, "node-1", true, ShardRoutingState.INITIALIZING);
         routingNode.add(initializingShard3);
         routingNode.add(relocatingShard4);
         routingNode.add(initializingShard5);
@@ -106,6 +110,8 @@ public class RoutingNodeTests extends OpenSearchTestCase {
         assertTrue(shardRoutingIterator.hasNext());
         assertThat(shardRoutingIterator.next(), equalTo(relocatingShard0));
         assertTrue(shardRoutingIterator.hasNext());
+        assertThat(shardRoutingIterator.next(), equalTo(splittingShard0));
+        assertTrue(shardRoutingIterator.hasNext());
         assertThat(shardRoutingIterator.next(), equalTo(initializingShard3));
         assertFalse(shardRoutingIterator.hasNext());
     }
@@ -114,9 +120,11 @@ public class RoutingNodeTests extends OpenSearchTestCase {
         ShardRouting startedShard0 = TestShardRouting.newShardRouting("test", 0, "node-1", false, ShardRoutingState.STARTED);
         ShardRouting startedShard1 = TestShardRouting.newShardRouting("test", 1, "node-1", "node-2", false, ShardRoutingState.RELOCATING);
         ShardRouting startedShard2 = TestShardRouting.newShardRouting("test", 2, "node-1", false, ShardRoutingState.INITIALIZING);
+        ShardRouting startedShard3 = TestShardRouting.newShardRouting("test", 3, "node-1", false, ShardRoutingState.SPLITTING);
         routingNode.update(unassignedShard0, startedShard0);
         routingNode.update(initializingShard0, startedShard1);
         routingNode.update(relocatingShard0, startedShard2);
+        routingNode.update(splittingShard0, startedShard3);
         assertThat(
             routingNode.getByShardId(new ShardId("test", IndexMetadata.INDEX_UUID_NA_VALUE, 0)).state(),
             equalTo(ShardRoutingState.STARTED)
@@ -129,15 +137,21 @@ public class RoutingNodeTests extends OpenSearchTestCase {
             routingNode.getByShardId(new ShardId("test", IndexMetadata.INDEX_UUID_NA_VALUE, 2)).state(),
             equalTo(ShardRoutingState.INITIALIZING)
         );
+        assertThat(
+            routingNode.getByShardId(new ShardId("test", IndexMetadata.INDEX_UUID_NA_VALUE, 3)).state(),
+            equalTo(ShardRoutingState.SPLITTING)
+        );
     }
 
     public void testRemove() {
         routingNode.remove(unassignedShard0);
         routingNode.remove(initializingShard0);
         routingNode.remove(relocatingShard0);
+        routingNode.remove(splittingShard0);
         assertThat(routingNode.getByShardId(new ShardId("test", IndexMetadata.INDEX_UUID_NA_VALUE, 0)), is(nullValue()));
         assertThat(routingNode.getByShardId(new ShardId("test", IndexMetadata.INDEX_UUID_NA_VALUE, 1)), is(nullValue()));
         assertThat(routingNode.getByShardId(new ShardId("test", IndexMetadata.INDEX_UUID_NA_VALUE, 2)), is(nullValue()));
+        assertThat(routingNode.getByShardId(new ShardId("test", IndexMetadata.INDEX_UUID_NA_VALUE, 3)), is(nullValue()));
     }
 
     public void testNumberOfShardsWithState() {
@@ -145,6 +159,7 @@ public class RoutingNodeTests extends OpenSearchTestCase {
         assertThat(routingNode.numberOfShardsWithState(ShardRoutingState.STARTED), equalTo(1));
         assertThat(routingNode.numberOfShardsWithState(ShardRoutingState.RELOCATING), equalTo(1));
         assertThat(routingNode.numberOfShardsWithState(ShardRoutingState.INITIALIZING), equalTo(1));
+        assertThat(routingNode.numberOfShardsWithState(ShardRoutingState.SPLITTING), equalTo(1));
     }
 
     public void testShardsWithState() {
@@ -152,6 +167,7 @@ public class RoutingNodeTests extends OpenSearchTestCase {
         assertThat(routingNode.shardsWithState(ShardRoutingState.STARTED).size(), equalTo(1));
         assertThat(routingNode.shardsWithState(ShardRoutingState.RELOCATING).size(), equalTo(1));
         assertThat(routingNode.shardsWithState(ShardRoutingState.INITIALIZING).size(), equalTo(1));
+        assertThat(routingNode.shardsWithState(ShardRoutingState.SPLITTING).size(), equalTo(1));
     }
 
     public void testShardsWithStateInIndex() {
@@ -159,10 +175,11 @@ public class RoutingNodeTests extends OpenSearchTestCase {
         assertThat(routingNode.shardsWithState("test", ShardRoutingState.STARTED).size(), equalTo(1));
         assertThat(routingNode.shardsWithState("test", ShardRoutingState.RELOCATING).size(), equalTo(1));
         assertThat(routingNode.shardsWithState("test", ShardRoutingState.INITIALIZING).size(), equalTo(1));
+        assertThat(routingNode.shardsWithState("test", ShardRoutingState.SPLITTING).size(), equalTo(1));
     }
 
     public void testNumberOfOwningShards() {
-        assertThat(routingNode.numberOfOwningShards(), equalTo(2));
+        assertThat(routingNode.numberOfOwningShards(), equalTo(3));
     }
 
     public void testNumberOfOwningShardsForIndex() {
@@ -177,10 +194,9 @@ public class RoutingNodeTests extends OpenSearchTestCase {
         );
         routingNode.add(test1Shard0);
         routingNode.add(test2Shard0);
-        assertThat(routingNode.numberOfOwningShardsForIndex(new Index("test", IndexMetadata.INDEX_UUID_NA_VALUE)), equalTo(2));
+        assertThat(routingNode.numberOfOwningShardsForIndex(new Index("test", IndexMetadata.INDEX_UUID_NA_VALUE)), equalTo(3));
         assertThat(routingNode.numberOfOwningShardsForIndex(new Index("test1", IndexMetadata.INDEX_UUID_NA_VALUE)), equalTo(1));
         assertThat(routingNode.numberOfOwningShardsForIndex(new Index("test2", IndexMetadata.INDEX_UUID_NA_VALUE)), equalTo(0));
         assertThat(routingNode.numberOfOwningShardsForIndex(new Index("test3", IndexMetadata.INDEX_UUID_NA_VALUE)), equalTo(0));
     }
-
 }

--- a/server/src/test/java/org/opensearch/cluster/routing/RoutingTableTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/RoutingTableTests.java
@@ -50,14 +50,10 @@ import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.repositories.IndexId;
 import org.junit.Before;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import static org.opensearch.cluster.routing.ShardRoutingState.INITIALIZING;
 import static org.opensearch.cluster.routing.ShardRoutingState.RELOCATING;
@@ -106,8 +102,8 @@ public class RoutingTableTests extends OpenSearchAllocationTestCase {
         Metadata metadata = Metadata.builder().put(createIndexMetadata(TEST_INDEX_1)).put(createIndexMetadata(TEST_INDEX_2)).build();
 
         RoutingTable testRoutingTable = new RoutingTable.Builder().add(
-            new IndexRoutingTable.Builder(metadata.index(TEST_INDEX_1).getIndex()).initializeAsNew(metadata.index(TEST_INDEX_1)).build()
-        )
+                new IndexRoutingTable.Builder(metadata.index(TEST_INDEX_1).getIndex()).initializeAsNew(metadata.index(TEST_INDEX_1)).build()
+            )
             .add(
                 new IndexRoutingTable.Builder(metadata.index(TEST_INDEX_2).getIndex()).initializeAsNew(metadata.index(TEST_INDEX_2)).build()
             )
@@ -294,7 +290,7 @@ public class RoutingTableTests extends OpenSearchAllocationTestCase {
             .build();
         clusterState = allocation.reroute(clusterState, "reroute");
 
-        String[] indices = new String[] { "test1", "test2" };
+        String[] indices = new String[]{"test1", "test2"};
         // Verifies against all primary shards on the node
         assertThat(clusterState.routingTable().allShardsSatisfyingPredicate(indices, ShardRouting::primary).size(), is(2));
         // Verifies against all replica shards on the node
@@ -308,49 +304,49 @@ public class RoutingTableTests extends OpenSearchAllocationTestCase {
         assertThat(this.emptyRoutingTable.activePrimaryShardsGrouped(new String[0], true).size(), is(0));
         assertThat(this.emptyRoutingTable.activePrimaryShardsGrouped(new String[0], false).size(), is(0));
 
-        assertThat(clusterState.routingTable().activePrimaryShardsGrouped(new String[] { TEST_INDEX_1 }, false).size(), is(0));
+        assertThat(clusterState.routingTable().activePrimaryShardsGrouped(new String[]{TEST_INDEX_1}, false).size(), is(0));
         assertThat(
-            clusterState.routingTable().activePrimaryShardsGrouped(new String[] { TEST_INDEX_1 }, true).size(),
+            clusterState.routingTable().activePrimaryShardsGrouped(new String[]{TEST_INDEX_1}, true).size(),
             is(this.numberOfShards)
         );
 
         initPrimaries();
-        assertThat(clusterState.routingTable().activePrimaryShardsGrouped(new String[] { TEST_INDEX_1 }, false).size(), is(0));
+        assertThat(clusterState.routingTable().activePrimaryShardsGrouped(new String[]{TEST_INDEX_1}, false).size(), is(0));
         assertThat(
-            clusterState.routingTable().activePrimaryShardsGrouped(new String[] { TEST_INDEX_1 }, true).size(),
+            clusterState.routingTable().activePrimaryShardsGrouped(new String[]{TEST_INDEX_1}, true).size(),
             is(this.numberOfShards)
         );
 
         startInitializingShards(TEST_INDEX_1);
         assertThat(
-            clusterState.routingTable().activePrimaryShardsGrouped(new String[] { TEST_INDEX_1 }, false).size(),
+            clusterState.routingTable().activePrimaryShardsGrouped(new String[]{TEST_INDEX_1}, false).size(),
             is(this.numberOfShards)
         );
         assertThat(
-            clusterState.routingTable().activePrimaryShardsGrouped(new String[] { TEST_INDEX_1, TEST_INDEX_2 }, false).size(),
+            clusterState.routingTable().activePrimaryShardsGrouped(new String[]{TEST_INDEX_1, TEST_INDEX_2}, false).size(),
             is(this.numberOfShards)
         );
         assertThat(
-            clusterState.routingTable().activePrimaryShardsGrouped(new String[] { TEST_INDEX_1 }, true).size(),
+            clusterState.routingTable().activePrimaryShardsGrouped(new String[]{TEST_INDEX_1}, true).size(),
             is(this.numberOfShards)
         );
 
         startInitializingShards(TEST_INDEX_2);
         assertThat(
-            clusterState.routingTable().activePrimaryShardsGrouped(new String[] { TEST_INDEX_2 }, false).size(),
+            clusterState.routingTable().activePrimaryShardsGrouped(new String[]{TEST_INDEX_2}, false).size(),
             is(this.numberOfShards)
         );
         assertThat(
-            clusterState.routingTable().activePrimaryShardsGrouped(new String[] { TEST_INDEX_1, TEST_INDEX_2 }, false).size(),
+            clusterState.routingTable().activePrimaryShardsGrouped(new String[]{TEST_INDEX_1, TEST_INDEX_2}, false).size(),
             is(2 * this.numberOfShards)
         );
         assertThat(
-            clusterState.routingTable().activePrimaryShardsGrouped(new String[] { TEST_INDEX_1, TEST_INDEX_2 }, true).size(),
+            clusterState.routingTable().activePrimaryShardsGrouped(new String[]{TEST_INDEX_1, TEST_INDEX_2}, true).size(),
             is(2 * this.numberOfShards)
         );
 
         try {
-            clusterState.routingTable().activePrimaryShardsGrouped(new String[] { TEST_INDEX_1, "not_exists" }, true);
+            clusterState.routingTable().activePrimaryShardsGrouped(new String[]{TEST_INDEX_1, "not_exists"}, true);
             fail("Calling with non-existing index name should raise IndexMissingException");
         } catch (IndexNotFoundException e) {
             // expected
@@ -361,73 +357,73 @@ public class RoutingTableTests extends OpenSearchAllocationTestCase {
         assertThat(this.emptyRoutingTable.allActiveShardsGrouped(new String[0], true).size(), is(0));
         assertThat(this.emptyRoutingTable.allActiveShardsGrouped(new String[0], false).size(), is(0));
 
-        assertThat(clusterState.routingTable().allActiveShardsGrouped(new String[] { TEST_INDEX_1 }, false).size(), is(0));
-        assertThat(clusterState.routingTable().allActiveShardsGrouped(new String[] { TEST_INDEX_1 }, true).size(), is(this.shardsPerIndex));
+        assertThat(clusterState.routingTable().allActiveShardsGrouped(new String[]{TEST_INDEX_1}, false).size(), is(0));
+        assertThat(clusterState.routingTable().allActiveShardsGrouped(new String[]{TEST_INDEX_1}, true).size(), is(this.shardsPerIndex));
 
         initPrimaries();
-        assertThat(clusterState.routingTable().allActiveShardsGrouped(new String[] { TEST_INDEX_1 }, false).size(), is(0));
-        assertThat(clusterState.routingTable().allActiveShardsGrouped(new String[] { TEST_INDEX_1 }, true).size(), is(this.shardsPerIndex));
+        assertThat(clusterState.routingTable().allActiveShardsGrouped(new String[]{TEST_INDEX_1}, false).size(), is(0));
+        assertThat(clusterState.routingTable().allActiveShardsGrouped(new String[]{TEST_INDEX_1}, true).size(), is(this.shardsPerIndex));
 
         startInitializingShards(TEST_INDEX_1);
         assertThat(
-            clusterState.routingTable().allActiveShardsGrouped(new String[] { TEST_INDEX_1 }, false).size(),
+            clusterState.routingTable().allActiveShardsGrouped(new String[]{TEST_INDEX_1}, false).size(),
             is(this.numberOfShards)
         );
         assertThat(
-            clusterState.routingTable().allActiveShardsGrouped(new String[] { TEST_INDEX_1, TEST_INDEX_2 }, false).size(),
+            clusterState.routingTable().allActiveShardsGrouped(new String[]{TEST_INDEX_1, TEST_INDEX_2}, false).size(),
             is(this.numberOfShards)
         );
-        assertThat(clusterState.routingTable().allActiveShardsGrouped(new String[] { TEST_INDEX_1 }, true).size(), is(this.shardsPerIndex));
+        assertThat(clusterState.routingTable().allActiveShardsGrouped(new String[]{TEST_INDEX_1}, true).size(), is(this.shardsPerIndex));
 
         startInitializingShards(TEST_INDEX_2);
         assertThat(
-            clusterState.routingTable().allActiveShardsGrouped(new String[] { TEST_INDEX_2 }, false).size(),
+            clusterState.routingTable().allActiveShardsGrouped(new String[]{TEST_INDEX_2}, false).size(),
             is(this.numberOfShards)
         );
         assertThat(
-            clusterState.routingTable().allActiveShardsGrouped(new String[] { TEST_INDEX_1, TEST_INDEX_2 }, false).size(),
+            clusterState.routingTable().allActiveShardsGrouped(new String[]{TEST_INDEX_1, TEST_INDEX_2}, false).size(),
             is(2 * this.numberOfShards)
         );
         assertThat(
-            clusterState.routingTable().allActiveShardsGrouped(new String[] { TEST_INDEX_1, TEST_INDEX_2 }, true).size(),
+            clusterState.routingTable().allActiveShardsGrouped(new String[]{TEST_INDEX_1, TEST_INDEX_2}, true).size(),
             is(this.totalNumberOfShards)
         );
 
         try {
-            clusterState.routingTable().allActiveShardsGrouped(new String[] { TEST_INDEX_1, "not_exists" }, true);
+            clusterState.routingTable().allActiveShardsGrouped(new String[]{TEST_INDEX_1, "not_exists"}, true);
         } catch (IndexNotFoundException e) {
             fail("Calling with non-existing index should be ignored at the moment");
         }
     }
 
     public void testAllAssignedShardsGrouped() {
-        assertThat(clusterState.routingTable().allAssignedShardsGrouped(new String[] { TEST_INDEX_1 }, false).size(), is(0));
+        assertThat(clusterState.routingTable().allAssignedShardsGrouped(new String[]{TEST_INDEX_1}, false).size(), is(0));
         assertThat(
-            clusterState.routingTable().allAssignedShardsGrouped(new String[] { TEST_INDEX_1 }, true).size(),
+            clusterState.routingTable().allAssignedShardsGrouped(new String[]{TEST_INDEX_1}, true).size(),
             is(this.shardsPerIndex)
         );
 
         initPrimaries();
         assertThat(
-            clusterState.routingTable().allAssignedShardsGrouped(new String[] { TEST_INDEX_1 }, false).size(),
+            clusterState.routingTable().allAssignedShardsGrouped(new String[]{TEST_INDEX_1}, false).size(),
             is(this.numberOfShards)
         );
         assertThat(
-            clusterState.routingTable().allAssignedShardsGrouped(new String[] { TEST_INDEX_1 }, true).size(),
+            clusterState.routingTable().allAssignedShardsGrouped(new String[]{TEST_INDEX_1}, true).size(),
             is(this.shardsPerIndex)
         );
 
         assertThat(
-            clusterState.routingTable().allAssignedShardsGrouped(new String[] { TEST_INDEX_1, TEST_INDEX_2 }, false).size(),
+            clusterState.routingTable().allAssignedShardsGrouped(new String[]{TEST_INDEX_1, TEST_INDEX_2}, false).size(),
             is(2 * this.numberOfShards)
         );
         assertThat(
-            clusterState.routingTable().allAssignedShardsGrouped(new String[] { TEST_INDEX_1, TEST_INDEX_2 }, true).size(),
+            clusterState.routingTable().allAssignedShardsGrouped(new String[]{TEST_INDEX_1, TEST_INDEX_2}, true).size(),
             is(this.totalNumberOfShards)
         );
 
         try {
-            clusterState.routingTable().allAssignedShardsGrouped(new String[] { TEST_INDEX_1, "not_exists" }, false);
+            clusterState.routingTable().allAssignedShardsGrouped(new String[]{TEST_INDEX_1, "not_exists"}, false);
         } catch (IndexNotFoundException e) {
             fail("Calling with non-existing index should be ignored at the moment");
         }
@@ -436,19 +432,19 @@ public class RoutingTableTests extends OpenSearchAllocationTestCase {
     public void testAllShardsForMultipleIndices() {
         assertThat(this.emptyRoutingTable.allShards(new String[0]).size(), is(0));
 
-        assertThat(clusterState.routingTable().allShards(new String[] { TEST_INDEX_1 }).size(), is(this.shardsPerIndex));
+        assertThat(clusterState.routingTable().allShards(new String[]{TEST_INDEX_1}).size(), is(this.shardsPerIndex));
 
         initPrimaries();
-        assertThat(clusterState.routingTable().allShards(new String[] { TEST_INDEX_1 }).size(), is(this.shardsPerIndex));
+        assertThat(clusterState.routingTable().allShards(new String[]{TEST_INDEX_1}).size(), is(this.shardsPerIndex));
 
         startInitializingShards(TEST_INDEX_1);
-        assertThat(clusterState.routingTable().allShards(new String[] { TEST_INDEX_1 }).size(), is(this.shardsPerIndex));
+        assertThat(clusterState.routingTable().allShards(new String[]{TEST_INDEX_1}).size(), is(this.shardsPerIndex));
 
         startInitializingShards(TEST_INDEX_2);
-        assertThat(clusterState.routingTable().allShards(new String[] { TEST_INDEX_1, TEST_INDEX_2 }).size(), is(this.totalNumberOfShards));
+        assertThat(clusterState.routingTable().allShards(new String[]{TEST_INDEX_1, TEST_INDEX_2}).size(), is(this.totalNumberOfShards));
 
         try {
-            clusterState.routingTable().allShards(new String[] { TEST_INDEX_1, "not_exists" });
+            clusterState.routingTable().allShards(new String[]{TEST_INDEX_1, "not_exists"});
         } catch (IndexNotFoundException e) {
             fail("Calling with non-existing index should be ignored at the moment");
         }
@@ -470,7 +466,7 @@ public class RoutingTableTests extends OpenSearchAllocationTestCase {
             assertThat(e.getMessage(), containsString("cannot be reused"));
         }
         try {
-            b.updateNumberOfReplicas(1, new String[] { "foo" });
+            b.updateNumberOfReplicas(1, new String[]{"foo"});
             fail("expected exception");
         } catch (IllegalStateException e) {
             assertThat(e.getMessage(), containsString("cannot be reused"));
@@ -695,7 +691,9 @@ public class RoutingTableTests extends OpenSearchAllocationTestCase {
         );
     }
 
-    /** reverse engineer the in sync aid based on the given indexRoutingTable **/
+    /**
+     * reverse engineer the in sync aid based on the given indexRoutingTable
+     **/
     public static IndexMetadata updateActiveAllocations(IndexRoutingTable indexRoutingTable, IndexMetadata indexMetadata) {
         IndexMetadata.Builder imdBuilder = IndexMetadata.builder(indexMetadata);
         for (IndexShardRoutingTable shardTable : indexRoutingTable) {
@@ -715,4 +713,226 @@ public class RoutingTableTests extends OpenSearchAllocationTestCase {
         return imdBuilder.build();
     }
 
+    public void testChildReplicaShardRoutingTable() {
+        ShardId shardId = new ShardId("test", "_na_", 0);
+        Index index = shardId.getIndex();
+
+        // Create primary and replica shards
+        ShardRouting primaryShard = TestShardRouting.newShardRouting(shardId, "node1", true, ShardRoutingState.STARTED);
+        ShardRouting replicaShard = TestShardRouting.newShardRouting(shardId, "node2", false, ShardRoutingState.STARTED);
+
+        // Create main shard routing table
+        Map<Integer, IndexShardRoutingTable> shards = new HashMap<>();
+        shards.put(shardId.id(), new IndexShardRoutingTable(shardId, Arrays.asList(primaryShard, replicaShard)));
+
+        // Create child replica routing table
+        ShardRouting childReplica1 = TestShardRouting.newShardRouting(shardId, "node3", false, ShardRoutingState.STARTED);
+        ShardRouting childReplica2 = TestShardRouting.newShardRouting(shardId, "node4", false, ShardRoutingState.STARTED);
+        Map<Integer, IndexShardRoutingTable> childReplicas = new HashMap<>();
+        childReplicas.put(shardId.id(), new IndexShardRoutingTable(shardId, Arrays.asList(childReplica1, childReplica2)));
+
+        // Create IndexRoutingTable
+        IndexRoutingTable indexRoutingTable = new IndexRoutingTable(index, shards, childReplicas);
+
+        // Create the routing table
+        RoutingTable routingTable = RoutingTable.builder()
+            .add(indexRoutingTable)
+            .build();
+
+        // Test successful case
+        IndexShardRoutingTable result = routingTable.childReplicaShardRoutingTable(shardId);
+        assertNotNull("Child replica shard routing table should not be null", result);
+        assertEquals("ShardId should match", shardId, result.shardId());
+
+        // Verify child replicas
+        List<ShardRouting> resultChildReplicas = new ArrayList<>();
+        result.forEach(resultChildReplicas::add);
+        assertEquals("Should have 2 child replicas", 2, resultChildReplicas.size());
+        assertTrue("Should contain child replica 1", resultChildReplicas.contains(childReplica1));
+        assertTrue("Should contain child replica 2", resultChildReplicas.contains(childReplica2));
+    }
+
+    public void testChildReplicaShardRoutingTableWithMultipleShards() {
+        ShardId shardId0 = new ShardId("test", "_na_", 0);
+        ShardId shardId1 = new ShardId("test", "_na_", 1);
+        Index index = shardId0.getIndex();
+
+        // Create shards for shard 0
+        ShardRouting primaryShard0 = TestShardRouting.newShardRouting(shardId0, "node1", true, ShardRoutingState.STARTED);
+        ShardRouting replicaShard0 = TestShardRouting.newShardRouting(shardId0, "node2", false, ShardRoutingState.STARTED);
+
+        // Create shards for shard 1
+        ShardRouting primaryShard1 = TestShardRouting.newShardRouting(shardId1, "node3", true, ShardRoutingState.STARTED);
+        ShardRouting replicaShard1 = TestShardRouting.newShardRouting(shardId1, "node4", false, ShardRoutingState.STARTED);
+
+        // Create main shard routing tables
+        Map<Integer, IndexShardRoutingTable> shards = new HashMap<>();
+        shards.put(shardId0.id(), new IndexShardRoutingTable(shardId0, Arrays.asList(primaryShard0, replicaShard0)));
+        shards.put(shardId1.id(), new IndexShardRoutingTable(shardId1, Arrays.asList(primaryShard1, replicaShard1)));
+
+        // Create child replica routing tables
+        Map<Integer, IndexShardRoutingTable> childReplicas = new HashMap<>();
+        ShardRouting childReplica0 = TestShardRouting.newShardRouting(shardId0, "node5", false, ShardRoutingState.STARTED);
+        ShardRouting childReplica1 = TestShardRouting.newShardRouting(shardId1, "node6", false, ShardRoutingState.STARTED);
+        childReplicas.put(shardId0.id(), new IndexShardRoutingTable(shardId0, Collections.singletonList(childReplica0)));
+        childReplicas.put(shardId1.id(), new IndexShardRoutingTable(shardId1, Collections.singletonList(childReplica1)));
+
+        // Create IndexRoutingTable
+        IndexRoutingTable indexRoutingTable = new IndexRoutingTable(index, shards, childReplicas);
+
+        // Create the routing table
+        RoutingTable routingTable = RoutingTable.builder()
+            .add(indexRoutingTable)
+            .build();
+
+        // Test shard 0
+        IndexShardRoutingTable result0 = routingTable.childReplicaShardRoutingTable(shardId0);
+        assertNotNull("Child replica shard routing table for shard 0 should not be null", result0);
+        assertEquals("Should have correct shard ID", shardId0, result0.shardId());
+        assertTrue("Should contain child replica for shard 0",
+            StreamSupport.stream(result0.spliterator(), false)
+                .anyMatch(shard -> shard.equals(childReplica0)));
+
+        // Test shard 1
+        IndexShardRoutingTable result1 = routingTable.childReplicaShardRoutingTable(shardId1);
+        assertNotNull("Child replica shard routing table for shard 1 should not be null", result1);
+        assertEquals("Should have correct shard ID", shardId1, result1.shardId());
+        assertTrue("Should contain child replica for shard 1",
+            StreamSupport.stream(result1.spliterator(), false)
+                .anyMatch(shard -> shard.equals(childReplica1)));
+    }
+
+    public void testUpdateNodesWithSplitTargetAndChildReplicaShards() {
+        long version = 1L;
+        RoutingNodes routingNodes = mock(RoutingNodes.class);
+        RoutingNode routingNode = mock(RoutingNode.class);
+
+        // Create proper Index and ShardId
+        Index index = new Index("test", "_na_");
+        ShardId shardId = new ShardId(index, 0);
+        ShardId shardId2 = new ShardId(index, 1);
+        ShardId shardId3 = new ShardId(index, 2);
+        ShardId shardId4 = new ShardId(index, 3);
+        ShardId shardId5 = new ShardId(index, 4);
+        ShardId parentShardId = new ShardId(index, 5); // Parent shard ID
+
+        // 1. Normal shard (should be included)
+        ShardRouting normalShard = mock(ShardRouting.class);
+        when(normalShard.shardId()).thenReturn(shardId);
+        when(normalShard.id()).thenReturn(shardId.id());
+        when(normalShard.index()).thenReturn(index);
+        when(normalShard.state()).thenReturn(ShardRoutingState.STARTED);
+        when(normalShard.initializing()).thenReturn(false);
+        when(normalShard.isSplitTarget()).thenReturn(false);
+        when(normalShard.unassigned()).thenReturn(false);
+        when(normalShard.primary()).thenReturn(true);
+        when(normalShard.started()).thenReturn(true);
+
+        // 2. Split target shard (should be ignored)
+        ShardRouting splitTargetShard = mock(ShardRouting.class);
+        when(splitTargetShard.shardId()).thenReturn(shardId2);
+        when(splitTargetShard.id()).thenReturn(shardId2.id());
+        when(splitTargetShard.index()).thenReturn(index);
+        when(splitTargetShard.state()).thenReturn(ShardRoutingState.INITIALIZING);
+        when(splitTargetShard.initializing()).thenReturn(true);
+        when(splitTargetShard.isSplitTarget()).thenReturn(true);
+        when(splitTargetShard.relocatingNodeId()).thenReturn(null);
+        when(splitTargetShard.unassigned()).thenReturn(false);
+        when(splitTargetShard.primary()).thenReturn(false);
+        when(splitTargetShard.started()).thenReturn(false);
+
+        // 3. Started child replica shard (should be included)
+        ShardRouting startedChildReplicaShard = mock(ShardRouting.class);
+        when(startedChildReplicaShard.shardId()).thenReturn(shardId3);
+        when(startedChildReplicaShard.id()).thenReturn(shardId3.id());
+        when(startedChildReplicaShard.index()).thenReturn(index);
+        when(startedChildReplicaShard.state()).thenReturn(ShardRoutingState.STARTED);
+        when(startedChildReplicaShard.initializing()).thenReturn(false);
+        when(startedChildReplicaShard.isStartedChildReplica()).thenReturn(true);
+        when(startedChildReplicaShard.unassigned()).thenReturn(false);
+        when(startedChildReplicaShard.primary()).thenReturn(false);
+        when(startedChildReplicaShard.started()).thenReturn(true);
+        when(startedChildReplicaShard.getParentShardId()).thenReturn(parentShardId);
+
+        // 4. Initializing child replica (should be included)
+        ShardRouting initializingChildReplicaShard = mock(ShardRouting.class);
+        when(initializingChildReplicaShard.shardId()).thenReturn(shardId4);
+        when(initializingChildReplicaShard.id()).thenReturn(shardId4.id());
+        when(initializingChildReplicaShard.index()).thenReturn(index);
+        when(initializingChildReplicaShard.state()).thenReturn(ShardRoutingState.INITIALIZING);
+        when(initializingChildReplicaShard.initializing()).thenReturn(true);
+        when(initializingChildReplicaShard.isStartedChildReplica()).thenReturn(false);
+        when(initializingChildReplicaShard.relocatingNodeId()).thenReturn(null);
+        when(initializingChildReplicaShard.unassigned()).thenReturn(false);
+        when(initializingChildReplicaShard.primary()).thenReturn(false);
+        when(initializingChildReplicaShard.started()).thenReturn(false);
+        when(initializingChildReplicaShard.getParentShardId()).thenReturn(parentShardId);
+
+        // 5. Initializing shard with relocating node (should be ignored)
+        ShardRouting relocatingTargetShard = mock(ShardRouting.class);
+        when(relocatingTargetShard.shardId()).thenReturn(shardId5);
+        when(relocatingTargetShard.id()).thenReturn(shardId5.id());
+        when(relocatingTargetShard.index()).thenReturn(index);
+        when(relocatingTargetShard.state()).thenReturn(ShardRoutingState.INITIALIZING);
+        when(relocatingTargetShard.initializing()).thenReturn(true);
+        when(relocatingTargetShard.relocatingNodeId()).thenReturn("sourceNode");
+        when(relocatingTargetShard.unassigned()).thenReturn(false);
+        when(relocatingTargetShard.primary()).thenReturn(false);
+        when(relocatingTargetShard.started()).thenReturn(false);
+
+        // Setup routing nodes
+        List<ShardRouting> allShards = Arrays.asList(
+            normalShard,
+            splitTargetShard,
+            startedChildReplicaShard,
+            initializingChildReplicaShard,
+            relocatingTargetShard
+        );
+        when(routingNodes.iterator()).thenReturn(Collections.singletonList(routingNode).iterator());
+        when(routingNode.iterator()).thenReturn(allShards.iterator());
+
+        // Create empty UnassignedShards instance
+        RoutingNodes.UnassignedShards unassignedShards = new RoutingNodes.UnassignedShards(
+            routingNodes
+        );
+        when(routingNodes.unassigned()).thenReturn(unassignedShards);
+
+        // Execute builder
+        RoutingTable.Builder builder = RoutingTable.builder();
+        builder.updateNodes(version, routingNodes);
+        RoutingTable routingTable = builder.build();
+
+        // Verify
+        IndexRoutingTable indexRoutingTable = routingTable.index("test");
+        assertNotNull("Should have routing for test index", indexRoutingTable);
+
+        // Get all shards in the routing table
+        List<ShardRouting> resultShards = new ArrayList<>();
+        for(IndexShardRoutingTable shardRoutingTable : indexRoutingTable.getShards().values()) {
+            for (ShardRouting shardRouting : shardRoutingTable) {
+                resultShards.add(shardRouting);
+            }
+        }
+        for(IndexShardRoutingTable shardRoutingTable : indexRoutingTable.getChildReplicas().values()) {
+            for (ShardRouting shardRouting : shardRoutingTable) {
+                resultShards.add(shardRouting);
+            }
+        }
+
+        // Verify specific cases
+        assertTrue("Should contain normal shard",
+            resultShards.contains(normalShard));
+
+        assertFalse("Should not contain split target shard",
+            resultShards.contains(splitTargetShard));
+
+        assertTrue("Should contain started child replica shard" + resultShards,
+            resultShards.contains(startedChildReplicaShard));
+
+        assertTrue("Should contain initializing child replica shard",
+            resultShards.contains(initializingChildReplicaShard));
+
+        assertFalse("Should not contain relocating target shard",
+            resultShards.contains(relocatingTargetShard));
+    }
 }

--- a/server/src/test/java/org/opensearch/cluster/routing/ShardRoutingTests.java
+++ b/server/src/test/java/org/opensearch/cluster/routing/ShardRoutingTests.java
@@ -44,6 +44,32 @@ import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
 
+import java.util.*;
+
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import static org.mockito.Mockito.*;
+import static org.opensearch.cluster.routing.ShardRouting.UNAVAILABLE_EXPECTED_SHARD_SIZE;
+
+import org.opensearch.cluster.routing.RecoverySource;
+import org.opensearch.cluster.routing.ShardRouting;
+import org.opensearch.cluster.routing.ShardRoutingState;
+import org.opensearch.cluster.routing.TestShardRouting;
+
+import org.opensearch.cluster.metadata.ShardRange;
+//import org.opensearch.cluster.routing.allocation.AllocationId;
+import org.opensearch.cluster.routing.allocation.allocator.BalancedShardsAllocator;
+
+//import org.junit.jupiter.api.Test;
+//import static org.junit.jupiter.api.Assertions.*;
+
+//import org.junit.jupiter.api.Test;
+//import org.opensearch.cluster.routing.*;
+//import static org.hamcrest.Matchers.*;
+//import static org.junit.jupiter.api.Assertions.*;
+//import org.opensearch.cluster.routing.allocation.AllocationId;
+
 public class ShardRoutingTests extends OpenSearchTestCase {
 
     public void testIsSameAllocation() {
@@ -345,5 +371,1529 @@ public class ShardRoutingTests extends OpenSearchTestCase {
                 assertEquals(byteSize, routing.getExpectedShardSize());
             }
         }
+    }
+    /**
+     * Test case for assignChildShards method
+     */
+    public void test_assignChildShards_1() {
+        // Arrange
+        ShardId parentShardId = new ShardId("test_index", "_na_", 0);
+        ShardRouting parentShard = TestShardRouting.newShardRouting(parentShardId, "node1", true, ShardRoutingState.STARTED);
+
+        // Create child shards
+        ShardId childShardId1 = new ShardId("test_index", "_na_", 1);
+        ShardId childShardId2 = new ShardId("test_index", "_na_", 2);
+        ShardRouting childShard1 = TestShardRouting.newShardRouting(childShardId1, null, true, ShardRoutingState.UNASSIGNED);
+        ShardRouting childShard2 = TestShardRouting.newShardRouting(childShardId2, null, false, ShardRoutingState.UNASSIGNED);
+
+        // Create assigned routing nodes map
+        Map<ShardRouting, String> assignedRoutingNodes = new HashMap<>();
+        assignedRoutingNodes.put(childShard1, "node2");
+        assignedRoutingNodes.put(childShard2, "node3");
+
+        // Create a splitting shard
+        ShardRouting splittingShard = new ShardRouting(
+            parentShardId,
+            parentShard.currentNodeId(),
+            null,
+            parentShard.primary(),
+            parentShard.isSearchOnly(),
+            ShardRoutingState.SPLITTING,
+            parentShard.recoverySource(),
+            parentShard.unassignedInfo(),
+            parentShard.allocationId(),
+            1000L,
+            new ShardRouting[]{childShard1, childShard2},
+            null
+        );
+
+        // Act
+        List<ShardRouting> result = splittingShard.assignChildShards(assignedRoutingNodes);
+
+        // Assert
+        assertNotNull("Result should not be null", result);
+        assertEquals("Should assign correct number of child shards", 2, result.size());
+
+        for (ShardRouting assignedChildShard : result) {
+            assertTrue("Assigned child shard should be initializing", assignedChildShard.initializing());
+            assertEquals("Assigned child shard should be in INITIALIZING state", ShardRoutingState.INITIALIZING, assignedChildShard.state());
+            assertTrue("Assigned node should be in the assignedRoutingNodes map", assignedRoutingNodes.containsValue(assignedChildShard.currentNodeId()));
+            assertEquals("Parent shard ID should match", parentShardId, assignedChildShard.getParentShardId());
+        }
+
+    }
+
+    /**
+     * Negative test cases for `assignChildShards`
+     */
+    public void test_assignChildShards_negative_tests() {
+        ShardId parentShardId = new ShardId("test_index", "_na_", 0);
+        ShardRouting parentShard = TestShardRouting.newShardRouting(parentShardId, "node1", true, ShardRoutingState.SPLITTING);
+
+        // 1. Test with empty input
+        Map<ShardRouting, String> emptyMap = Collections.emptyMap();
+        List<ShardRouting> emptyResult = parentShard.assignChildShards(emptyMap);
+        assertTrue("Result should be empty for empty input", emptyResult.isEmpty());
+
+        // 2. Test with null input
+        assertThrows(NullPointerException.class, () -> parentShard.assignChildShards(null));
+
+        // 3. Test with incorrect input type
+        Map<String, String> incorrectMap = new HashMap<>();
+        incorrectMap.put("invalidKey", "invalidValue");
+        assertThrows(ClassCastException.class, () -> parentShard.assignChildShards((Map) incorrectMap));
+
+        // 4. Test with null child shard
+        Map<ShardRouting, String> nullChildMap = new HashMap<>();
+        nullChildMap.put(null, "node2");
+        assertThrows(NullPointerException.class, () -> parentShard.assignChildShards(nullChildMap));
+    }
+
+    /**
+     * Test case for updatedStartedReplicaOnParent method
+     * Path constraints: (childShard.equals(initializingReplica))
+     */
+    public void testUpdatedStartedReplicaOnParent() {
+        // Create a parent shard
+        ShardId parentShardId = new ShardId("test", "_na_", 0);
+        ShardRouting parentShard = TestShardRouting.newShardRouting(parentShardId, "node1", true, ShardRoutingState.STARTED);
+
+        // Create child shards
+        ShardId childShardId1 = new ShardId("test", "_na_", 1);
+        ShardId childShardId2 = new ShardId("test", "_na_", 2);
+
+        ShardRouting initializingReplica = TestShardRouting.newShardRouting(childShardId1, "node2", false, ShardRoutingState.INITIALIZING);
+        ShardRouting startedReplica = TestShardRouting.newShardRouting(childShardId1, "node2", false, ShardRoutingState.STARTED);
+        ShardRouting otherChildShard = TestShardRouting.newShardRouting(childShardId2, "node3", false, ShardRoutingState.STARTED);
+
+        // Create a parent shard with child shards
+        ShardRouting parentWithChildren = new ShardRouting(
+            parentShardId,
+            parentShard.currentNodeId(),
+            parentShard.relocatingNodeId(),
+            parentShard.primary(),
+            parentShard.isSearchOnly(),
+            parentShard.state(),
+            parentShard.recoverySource(),
+            parentShard.unassignedInfo(),
+            parentShard.allocationId(),
+            parentShard.getExpectedShardSize(),
+            new ShardRouting[]{initializingReplica, otherChildShard},
+            null
+        );
+
+        // Call the method under test
+        ShardRouting updatedParent = parentWithChildren.updatedStartedReplicaOnParent(initializingReplica, startedReplica);
+
+        // Assertions
+        assertNotNull(updatedParent);
+        assertEquals(parentShardId, updatedParent.shardId());
+        assertEquals(parentShard.currentNodeId(), updatedParent.currentNodeId());
+        assertEquals(parentShard.relocatingNodeId(), updatedParent.relocatingNodeId());
+        assertEquals(parentShard.primary(), updatedParent.primary());
+        assertEquals(parentShard.state(), updatedParent.state());
+
+        ShardRouting[] updatedChildShards = updatedParent.getRecoveringChildShards();
+        assertNotNull(updatedChildShards);
+        assertEquals(2, updatedChildShards.length);
+
+        // Check that the initializing replica was replaced with the started replica
+        assertTrue(updatedChildShards[0].equals(startedReplica));
+        assertTrue(updatedChildShards[1].equals(otherChildShard));
+    }
+    /**
+     * Negative test cases for `updatedStartedReplicaOnParent`
+     */
+    public void test_updatedStartedReplicaOnParent_negative_cases() {
+        ShardId parentShardId = new ShardId("test_index", "_na_", 0);
+        ShardId childShardId1 = new ShardId("test_index", "_na_", 1);
+        ShardId childShardId2 = new ShardId("test_index", "_na_", 2);
+
+        ShardRouting parentShard = TestShardRouting.newShardRouting(parentShardId, "node1", true, ShardRoutingState.STARTED);
+        ShardRouting initializingReplica = TestShardRouting.newShardRouting(childShardId1, "node2", false, ShardRoutingState.INITIALIZING);
+        ShardRouting startedReplica = TestShardRouting.newShardRouting(childShardId1, "node2", false, ShardRoutingState.STARTED);
+
+        ShardRouting[] childShards = new ShardRouting[]{
+            initializingReplica,
+            TestShardRouting.newShardRouting(childShardId2, "node3", false, ShardRoutingState.STARTED)
+        };
+
+        ShardRouting parentWithChildren = new ShardRouting(
+            parentShardId,
+            parentShard.currentNodeId(),
+            null,
+            parentShard.primary(),
+            parentShard.isSearchOnly(),
+            parentShard.state(),
+            parentShard.recoverySource(),
+            parentShard.unassignedInfo(),
+            parentShard.allocationId(),
+            parentShard.getExpectedShardSize(),
+            childShards,
+            null
+        );
+
+        // 2. Test with initializing replica that doesn't exist in child shards
+        ShardRouting nonExistentReplica = TestShardRouting.newShardRouting(
+            new ShardId("test_index", "_na_", 3), "node4", false, ShardRoutingState.INITIALIZING);
+        assertThrows(AssertionError.class, () ->
+            parentWithChildren.updatedStartedReplicaOnParent(nonExistentReplica, startedReplica));
+
+        // 3. Test with started replica that is primary
+        ShardRouting primaryStartedReplica = TestShardRouting.newShardRouting(childShardId1, "node2", true, ShardRoutingState.STARTED);
+        assertThrows(AssertionError.class, () ->
+            parentWithChildren.updatedStartedReplicaOnParent(initializingReplica, primaryStartedReplica));
+
+        // 5. Test with parent shard that has no child shards
+        ShardRouting parentWithNoChildren = new ShardRouting(
+            parentShardId,
+            parentShard.currentNodeId(),
+            null,
+            parentShard.primary(),
+            parentShard.isSearchOnly(),
+            parentShard.state(),
+            parentShard.recoverySource(),
+            parentShard.unassignedInfo(),
+            parentShard.allocationId(),
+            parentShard.getExpectedShardSize(),
+            new ShardRouting[0],
+            null
+        );
+        assertThrows(AssertionError.class, () ->
+            parentWithNoChildren.updatedStartedReplicaOnParent(initializingReplica, startedReplica));
+    }
+
+    /**
+     * Test cancelSplit when shard is not assigned to a node. We already have an assertion test for this hence it gives an assertion error
+     */
+    public void testCancelSplitWhenNotAssignedToNode() {
+
+        assertThrows(AssertionError.class, () -> {
+            TestShardRouting.newShardRouting("test", 0, null, true, ShardRoutingState.SPLITTING);
+        });
+    }
+
+    /**
+     * Test cancelSplit when shard is not in SPLITTING state
+     */
+    public void testCancelSplitWhenNotSplitting() {
+        ShardRouting shardRouting = TestShardRouting.newShardRouting("test", 0, "node1", true, ShardRoutingState.STARTED);
+
+        assertThrows(AssertionError.class, () -> {
+            shardRouting.cancelSplit();
+        });
+    }
+
+    /**
+     * Test cancelSplit when shard has no recovering child shards
+     */
+    public void testCancelSplitWithNoRecoveringChildShards() {
+        ShardId shardId = new ShardId("test", "_na_", 0);
+        ShardRouting shardRouting = new ShardRouting(
+            shardId,
+            "node1",
+            null,
+            true,
+            false,
+            ShardRoutingState.SPLITTING,
+            null,
+            null,
+            AllocationId.newInitializing(),
+            0,
+            null,
+            null
+        );
+
+        assertThrows(AssertionError.class, () -> {
+            shardRouting.cancelSplit();
+        });
+    }
+
+    /**
+     * Test cancelSplit with null AllocationId
+     */
+    public void testCancelSplitWithNullAllocationId() {
+        ShardId shardId = new ShardId("test", "_na_", 0);
+        ShardRouting shardRouting = new ShardRouting(
+            shardId,
+            "node1",
+            null,
+            true,
+            false,
+            ShardRoutingState.SPLITTING,
+            null,
+            null,
+            null,
+            0,
+            new ShardRouting[]{mock(ShardRouting.class)},
+            null
+        );
+
+        assertThrows(NullPointerException.class, () -> {
+            shardRouting.cancelSplit();
+        });
+    }
+
+    /**
+     * Test case for public ShardRouting cancelSplit()
+     * This test verifies that the cancelSplit method correctly cancels the split operation
+     * and returns a new ShardRouting with the expected properties.
+     */
+    public void test_cancelSplit_1() {
+        // Arrange
+        ShardId shardId = new ShardId("test_index", "_na_", 0);
+        String currentNodeId = "node1";
+        boolean primary = true;
+        boolean searchOnly = false;
+        AllocationId allocationId = AllocationId.newSplit(AllocationId.newInitializing(), 2);
+
+        // Mocking recoveringChildShards to satisfy the assert condition
+        ShardRouting[] recoveringChildShards = new ShardRouting[]{
+            TestShardRouting.newShardRouting(new ShardId("test_index", "_na_", 1), null, true, ShardRoutingState.UNASSIGNED)
+        };
+
+        ShardRouting splittingShard = new ShardRouting(
+            shardId,
+            currentNodeId,
+            null,
+            primary,
+            searchOnly,
+            ShardRoutingState.SPLITTING,
+            null,
+            null,
+            allocationId,
+            UNAVAILABLE_EXPECTED_SHARD_SIZE,
+            recoveringChildShards,
+            null
+        );
+
+        // Act
+        ShardRouting result = splittingShard.cancelSplit();
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(shardId, result.shardId());
+        assertEquals(currentNodeId, result.currentNodeId());
+        assertNull(result.relocatingNodeId());
+        assertEquals(primary, result.primary());
+        assertEquals(searchOnly, result.isSearchOnly());
+        assertEquals(ShardRoutingState.STARTED, result.state());
+        assertNull(result.recoverySource());
+        assertNull(result.unassignedInfo());
+        assertEquals(AllocationId.cancelSplit(allocationId), result.allocationId());
+        assertEquals(UNAVAILABLE_EXPECTED_SHARD_SIZE, result.getExpectedShardSize());
+        assertNull(result.getRecoveringChildShards());
+        assertNull(result.getParentShardId());
+    }
+
+    public void testSplittingForDifferentStates() {
+        ShardId shardId = new ShardId(new Index("test-index", UUID.randomUUID().toString()), 0);
+        // Test STARTED state
+        ShardRouting startedShard = TestShardRouting.newShardRouting(
+            shardId,
+            "node-1",
+            true,
+            ShardRoutingState.STARTED
+        );
+        assertFalse("Started shard should not be splitting", startedShard.splitting());
+
+        // Test INITIALIZING state
+        ShardRouting initializingShard = TestShardRouting.newShardRouting(
+            shardId,
+            "node-1",
+            true,
+            ShardRoutingState.INITIALIZING
+        );
+        assertFalse("Initializing shard should not be splitting", initializingShard.splitting());
+
+        // Test RELOCATING state
+        ShardRouting relocatingShard = TestShardRouting.newShardRouting(
+            shardId,
+            "node-1",
+            "node-2",
+            true,
+            ShardRoutingState.RELOCATING
+        );
+        assertFalse("Relocating shard should not be splitting", relocatingShard.splitting());
+
+        // Test UNASSIGNED state
+        ShardRouting unassignedShard = ShardRouting.newUnassigned(
+            shardId,
+            true,
+            RecoverySource.PeerRecoverySource.INSTANCE,
+            new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, null)
+        );
+        assertFalse("Unassigned shard should not be splitting", unassignedShard.splitting());
+
+        // Create a shard in SPLITTING state
+        ShardRouting splittingShard = TestShardRouting.newShardRouting(
+            shardId,
+            "node-1",
+            null,
+            true,
+            ShardRoutingState.SPLITTING
+        );
+
+        assertTrue("Shard should be in splitting state", splittingShard.splitting());
+    }
+
+    public void testAssignChildShardsWithEmptyInput() {
+        ShardRouting parentShard = TestShardRouting.newShardRouting("test", 0, "node1", true, ShardRoutingState.STARTED);
+        Map<ShardRouting, String> emptyMap = Collections.emptyMap();
+
+        List<ShardRouting> result = parentShard.assignChildShards(emptyMap);
+
+        assertTrue("Result should be empty for empty input", result.isEmpty());
+    }
+
+    /**
+     * Test case for createRecoveringChildShards method
+     * This test verifies that the method correctly creates child shard routings for a splitting parent
+     */
+    public void testCreateRecoveringChildShards() {
+        // Arrange
+        ShardId parentShardId = new ShardId("test_index", "_na_", 0);
+        String currentNodeId = "node1";
+        boolean primary = true;
+        boolean searchOnly = false;
+        int replicaCount = 2;
+
+        ShardRouting parentShard = TestShardRouting.newShardRouting(parentShardId, currentNodeId, primary, ShardRoutingState.STARTED);
+
+        ShardRange[] recoveringChildShardRanges = new ShardRange[]{
+            new ShardRange(1, 0, 50),
+            new ShardRange(2, 51, 100)
+        };
+
+        // Act
+        ShardRouting result = parentShard.createRecoveringChildShards(recoveringChildShardRanges, replicaCount);
+
+        // Assert
+        assertNotNull("Result should not be null", result);
+        assertEquals("Shard ID should match parent", parentShardId, result.shardId());
+        assertEquals("Current node ID should match parent", currentNodeId, result.currentNodeId());
+        assertNull("Relocating node ID should be null", result.relocatingNodeId());
+        assertEquals("Primary flag should match parent", primary, result.primary());
+        assertEquals("Search only flag should match parent", searchOnly, result.isSearchOnly());
+        assertEquals("State should be SPLITTING", ShardRoutingState.SPLITTING, result.state());
+        assertNull("Unassigned info should be null", result.unassignedInfo());
+        assertNotNull("Allocation ID should not be null", result.allocationId());
+        assertEquals("Expected shard size should be unavailable", UNAVAILABLE_EXPECTED_SHARD_SIZE, result.getExpectedShardSize());
+
+        ShardRouting[] childShards = result.getRecoveringChildShards();
+        assertNotNull("Child shards should not be null", childShards);
+        assertEquals("Number of child shards should match expected", recoveringChildShardRanges.length * (replicaCount + 1), childShards.length);
+
+        for (int i = 0; i < recoveringChildShardRanges.length; i++) {
+            ShardRouting primaryChildShard = childShards[i * (replicaCount + 1)];
+            assertEquals("Child shard index should match", recoveringChildShardRanges[i].getShardId(), primaryChildShard.id());
+            assertTrue("Primary child shard should be primary", primaryChildShard.primary());
+            assertEquals("Primary child shard should be UNASSIGNED", ShardRoutingState.UNASSIGNED, primaryChildShard.state());
+            assertEquals("Primary child shard should have correct recovery source",
+                RecoverySource.InPlaceShardSplitRecoverySource.INSTANCE, primaryChildShard.recoverySource());
+
+            for (int j = 1; j <= replicaCount; j++) {
+                ShardRouting replicaChildShard = childShards[i * (replicaCount + 1) + j];
+                assertEquals("Replica child shard index should match", recoveringChildShardRanges[i].getShardId(), replicaChildShard.id());
+                assertFalse("Replica child shard should not be primary", replicaChildShard.primary());
+                assertEquals("Replica child shard should be UNASSIGNED", ShardRoutingState.UNASSIGNED, replicaChildShard.state());
+                assertEquals("Replica child shard should have peer recovery source",
+                    RecoverySource.PeerRecoverySource.INSTANCE, replicaChildShard.recoverySource());
+            }
+        }
+    }
+
+    public void testCreateRecoveringChildShardsWithInvalidParentState() {
+        ShardRouting parentShard = TestShardRouting.newShardRouting("test", 0, "node1", true, ShardRoutingState.INITIALIZING);
+        ShardRange[] ranges = new ShardRange[]{ mock(ShardRange.class) };
+
+        // Act & Assert
+        AssertionError error = assertThrows(
+            AssertionError.class,
+            () -> parentShard.createRecoveringChildShards(ranges, 1)
+        );
+
+        assertEquals(
+            "recovery source only available on unassigned or initializing shard but was SPLITTING",
+            error.getMessage()
+        );
+    }
+
+    public void testCreateRecoveringChildShardsWithNullShardRange() {
+        ShardRouting parentShard = TestShardRouting.newShardRouting("test", 0, "node1", true, ShardRoutingState.STARTED);
+        ShardRange[] ranges = new ShardRange[]{ null };
+
+        assertThrows(NullPointerException.class, () -> {
+            parentShard.createRecoveringChildShards(ranges, 1);
+        });
+
+    }
+
+    /**
+     * Test case for moveChildReplicaToStarted method
+     *
+     * This test verifies that the moveChildReplicaToStarted method correctly
+     * creates a new ShardRouting with the expected properties for a child replica
+     * shard that is being moved to the STARTED state.
+     */
+    public void testMoveChildReplicaToStarted() {
+        // Arrange
+        ShardId shardId = new ShardId("test_index", "_na_", 1);
+        String currentNodeId = "node1";
+        boolean primary = false;
+        boolean searchOnly = false;
+        ShardRoutingState initialState = ShardRoutingState.INITIALIZING;
+        RecoverySource recoverySource = RecoverySource.PeerRecoverySource.INSTANCE;
+        UnassignedInfo unassignedInfo = new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "test");
+        AllocationId allocationId = AllocationId.newInitializing();
+        long expectedShardSize = 1000L;
+        ShardId parentShardId = new ShardId("test_index", "_na_", 0);
+
+        ShardRouting childReplica = new ShardRouting(
+            shardId,
+            currentNodeId,
+            null,
+            primary,
+            searchOnly,
+            initialState,
+            recoverySource,
+            unassignedInfo,
+            allocationId,
+            expectedShardSize,
+            null,
+            parentShardId
+        );
+
+        // Act
+        ShardRouting result = childReplica.moveChildReplicaToStarted();
+
+        // Assert
+        assertNotNull("Result should not be null", result);
+        assertEquals("Shard ID should match", shardId, result.shardId());
+        assertEquals("Current node ID should match", currentNodeId, result.currentNodeId());
+        assertNull("Relocating node ID should be null", result.relocatingNodeId());
+        assertEquals("Primary flag should match", primary, result.primary());
+        assertEquals("Search only flag should match", searchOnly, result.isSearchOnly());
+        assertEquals("State should be STARTED", ShardRoutingState.STARTED, result.state());
+        assertNull("Recovery source should be null", result.recoverySource());
+        assertNull("Unassigned info should be null", result.unassignedInfo());
+        assertEquals("Allocation ID should match", allocationId, result.allocationId());
+        assertEquals("Expected shard size should be unavailable", UNAVAILABLE_EXPECTED_SHARD_SIZE, result.getExpectedShardSize());
+        assertNull("Recovering child shards should be null", result.getRecoveringChildShards());
+        assertEquals("Parent shard ID should match", parentShardId, result.getParentShardId());
+    }
+
+    public void testMoveChildReplicaToStartedWithAlreadyStartedShard() {
+        ShardRouting startedShard = TestShardRouting.newShardRouting("test", 0, "node1", false, ShardRoutingState.STARTED);
+        startedShard = new ShardRouting(startedShard.shardId(), startedShard.currentNodeId(), null, startedShard.primary(),
+            startedShard.isSearchOnly(), startedShard.state(), null, null, startedShard.allocationId(),
+            UNAVAILABLE_EXPECTED_SHARD_SIZE, null, new ShardId("test", "_na_", 1));
+
+        ShardRouting result = startedShard.moveChildReplicaToStarted();
+
+        assertEquals("Shard should remain in STARTED state", ShardRoutingState.STARTED, result.state());
+        assertEquals("Parent shard ID should not change", startedShard.getParentShardId(), result.getParentShardId());
+    }
+
+    public void testMoveToStartedFromNonInitializingState() {
+        ShardRouting unassignedShard = TestShardRouting.newShardRouting("test", 0, null, true, ShardRoutingState.UNASSIGNED);
+        assertThrows(AssertionError.class, unassignedShard::moveToStarted);
+
+        ShardRouting startedShard = TestShardRouting.newShardRouting("test", 0, "node1", true, ShardRoutingState.STARTED);
+        assertThrows(AssertionError.class, startedShard::moveToStarted);
+
+        ShardRouting relocatingShard = TestShardRouting.newShardRouting("test", 0, "node1", "node2", true, ShardRoutingState.RELOCATING);
+        assertThrows(AssertionError.class, relocatingShard::moveToStarted);
+    }
+
+    public void testMoveToStartedRetainsShardProperties() {
+        ShardRouting shard = TestShardRouting.newShardRouting("test", 0, "node1", true, ShardRoutingState.INITIALIZING);
+        ShardRouting result = shard.moveToStarted();
+
+        assertEquals(shard.shardId(), result.shardId());
+        assertEquals(shard.currentNodeId(), result.currentNodeId());
+        assertEquals(shard.primary(), result.primary());
+        assertEquals(ShardRoutingState.STARTED, result.state());
+        assertTrue(result.active());
+        assertNull(result.relocatingNodeId());
+        assertNull(result.recoverySource());
+        assertNull(result.unassignedInfo());
+    }
+
+    public void testMoveToStartedWithParentAllocationId() {
+        AllocationId parentAllocationId = AllocationId.newInitializing();
+        AllocationId childAllocationId = AllocationId.newInitializing(parentAllocationId.getId());
+        ShardRouting shard = new ShardRouting(
+            new ShardId("test", "_na_", 0),
+            "node1",
+            null,
+            true,
+            false,
+            ShardRoutingState.INITIALIZING,
+            RecoverySource.ExistingStoreRecoverySource.INSTANCE,
+            null,
+            childAllocationId,
+            0,
+            null,
+            new ShardId("test", "_na_", 1)
+        );
+
+        ShardRouting result = shard.moveToStarted();
+        assertNotNull(result);
+        assertEquals(ShardRoutingState.STARTED, result.state());
+        assertEquals(childAllocationId.getId(), result.allocationId().getId());
+        assertNull(result.allocationId().getParentAllocationId());
+    }
+
+    public void testMoveToStartedWithValidRelocationId() {
+        AllocationId allocationId = AllocationId.newRelocation(AllocationId.newInitializing());
+        ShardRouting shard = new ShardRouting(
+            new ShardId("test", "_na_", 0),
+            "node1",
+            "node2",
+            true,
+            false,
+            ShardRoutingState.INITIALIZING,
+            RecoverySource.ExistingStoreRecoverySource.INSTANCE,
+            null,
+            allocationId,
+            0,
+            null,
+            null
+        );
+
+        ShardRouting result = shard.moveToStarted();
+        assertNotNull(result);
+        assertEquals(ShardRoutingState.STARTED, result.state());
+        assertEquals(allocationId.getId(), result.allocationId().getId());
+    }
+
+    /**
+     * Test the correct behavior of removeParentFromReplica
+     */
+    public void testRemoveParentFromReplicaCorrectBehavior() {
+        ShardId parentShardId = new ShardId("test", "_na_", 0);
+        ShardId childShardId = new ShardId("test", "_na_", 1);
+
+        ShardRouting childReplica = new ShardRouting(
+            childShardId,
+            "node1",
+            null,
+            false,
+            false,
+            ShardRoutingState.STARTED,
+            null,
+            null,
+            AllocationId.newInitializing(),
+            UNAVAILABLE_EXPECTED_SHARD_SIZE,
+            null,
+            parentShardId
+        );
+
+        ShardRouting result = childReplica.removeParentFromReplica();
+
+        assertNotNull("Result should not be null", result);
+        assertEquals("Shard ID should remain unchanged", childShardId, result.shardId());
+        assertEquals("Node ID should remain unchanged", "node1", result.currentNodeId());
+        assertNull("Relocating node ID should be null", result.relocatingNodeId());
+        assertFalse("Should not be primary", result.primary());
+        assertFalse("Should not be search only", result.isSearchOnly());
+        assertEquals("State should be STARTED", ShardRoutingState.STARTED, result.state());
+        assertNull("Recovery source should be null", result.recoverySource());
+        assertNull("Unassigned info should be null", result.unassignedInfo());
+        assertEquals("Allocation ID should remain unchanged", childReplica.allocationId(), result.allocationId());
+        assertEquals("Expected shard size should be unavailable", UNAVAILABLE_EXPECTED_SHARD_SIZE, result.getExpectedShardSize());
+        assertNull("Recovering child shards should be null", result.getRecoveringChildShards());
+        assertNull("Parent shard ID should be null", result.getParentShardId());
+    }
+
+    /**
+     * Negative test cases for `removeParentFromReplica`
+     */
+    public void testRemoveParentFromReplicaNegativeCases() {
+        // Test case 1: Shard is not a started child replica
+        ShardRouting nonStartedChildReplica = TestShardRouting.newShardRouting("test", 0, "node1", false, ShardRoutingState.INITIALIZING);
+        assertThrows(AssertionError.class, nonStartedChildReplica::removeParentFromReplica);
+
+        // Test case 2: Shard is a primary
+        ShardRouting primaryShard = TestShardRouting.newShardRouting("test", 0, "node1", true, ShardRoutingState.STARTED);
+        assertThrows(AssertionError.class, primaryShard::removeParentFromReplica);
+
+        // Test case 3: Shard is not assigned to a node
+        ShardRouting unassignedShard = ShardRouting.newUnassigned(
+            new ShardId("test", "_na_", 0),
+            false,
+            RecoverySource.PeerRecoverySource.INSTANCE,
+            new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "test")
+        );
+        assertThrows(AssertionError.class, unassignedShard::removeParentFromReplica);
+
+        // Test case 4: Shard is not in STARTED state
+        ShardRouting initializingShard = TestShardRouting.newShardRouting("test", 0, "node1", false, ShardRoutingState.INITIALIZING);
+        assertThrows(AssertionError.class, initializingShard::removeParentFromReplica);
+
+        // Test case 5: Shard has no parent
+        ShardRouting noParentShard = TestShardRouting.newShardRouting("test", 0, "node1", false, ShardRoutingState.STARTED);
+        assertThrows(AssertionError.class, noParentShard::removeParentFromReplica);
+    }
+
+
+    /**
+     * Negative test cases for `getParentShardId`
+     */
+    public void testGetParentShardIdNegativeCases() {
+        // Test case 1: Shard with no parent
+        ShardRouting shardWithNoParent = TestShardRouting.newShardRouting("test", 0, "node1", true, ShardRoutingState.STARTED);
+        assertNull("Shard with no parent should return null", shardWithNoParent.getParentShardId());
+
+        // Test case 2: Unassigned shard
+        ShardRouting unassignedShard = ShardRouting.newUnassigned(
+            new ShardId("test", "_na_", 0),
+            true,
+            RecoverySource.EmptyStoreRecoverySource.INSTANCE,
+            new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "test")
+        );
+        assertNull("Unassigned shard should return null", unassignedShard.getParentShardId());
+
+        // Test case 3: Initializing shard without parent
+        ShardRouting initializingShard = TestShardRouting.newShardRouting("test", 0, "node1", true, ShardRoutingState.INITIALIZING);
+        assertNull("Initializing shard without parent should return null", initializingShard.getParentShardId());
+
+        // Test case 4: Relocating shard
+        ShardRouting relocatingShard = TestShardRouting.newShardRouting("test", 0, "node1", "node2", true, ShardRoutingState.RELOCATING);
+        assertNull("Relocating shard should return null", relocatingShard.getParentShardId());
+    }
+
+    /**
+     * Negative test cases for `getRecoveringChildShards`
+     */
+    public void testGetRecoveringChildShardsNegativeCases() {
+        // Test case 1: Shard with no recovering child shards
+        ShardRouting shardWithNoChildren = TestShardRouting.newShardRouting("test", 0, "node1", true, ShardRoutingState.STARTED);
+        assertNull("Should return null for shard with no recovering child shards", shardWithNoChildren.getRecoveringChildShards());
+
+        // Test case 2: Unassigned shard
+        ShardRouting unassignedShard = ShardRouting.newUnassigned(
+            new ShardId("test", "_na_", 0),
+            true,
+            RecoverySource.EmptyStoreRecoverySource.INSTANCE,
+            new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "test")
+        );
+        assertNull("Should return null for unassigned shard", unassignedShard.getRecoveringChildShards());
+
+        // Test case 3: Initializing shard
+        ShardRouting initializingShard = TestShardRouting.newShardRouting("test", 0, "node1", true, ShardRoutingState.INITIALIZING);
+        assertNull("Should return null for initializing shard", initializingShard.getRecoveringChildShards());
+
+        // Test case 4: Relocating shard
+        ShardRouting relocatingShard = TestShardRouting.newShardRouting("test", 0, "node1", "node2", true, ShardRoutingState.RELOCATING);
+        assertNull("Should return null for relocating shard", relocatingShard.getRecoveringChildShards());
+
+        // Test case 5: Non-primary shard
+        ShardRouting replicaShard = TestShardRouting.newShardRouting("test", 0, "node1", false, ShardRoutingState.STARTED);
+        assertNull("Should return null for non-primary shard", replicaShard.getRecoveringChildShards());
+
+    }
+
+    /**
+     * Test case for getParentShardId method
+     *
+     * This test verifies that the getParentShardId method correctly returns the parent shard ID
+     * when it is set, and returns null when it is not set.
+     */
+    public void test_getParentShardId_1() {
+        // Arrange
+        ShardId childShardId = new ShardId("test_index", "_na_", 1);
+        ShardId parentShardId = new ShardId("test_index", "_na_", 0);
+
+        // Create a shard routing with a parent shard ID
+        ShardRouting shardWithParent = new ShardRouting(
+            childShardId,
+            "node1",
+            null,
+            false,
+            false,
+            ShardRoutingState.STARTED,
+            null,
+            null,
+            AllocationId.newInitializing(),
+            UNAVAILABLE_EXPECTED_SHARD_SIZE,
+            null,
+            parentShardId
+        );
+
+        // Create a shard routing without a parent shard ID
+        ShardRouting shardWithoutParent = new ShardRouting(
+            childShardId,
+            "node1",
+            null,
+            false,
+            false,
+            ShardRoutingState.STARTED,
+            null,
+            null,
+            AllocationId.newInitializing(),
+            UNAVAILABLE_EXPECTED_SHARD_SIZE,
+            null,
+            null
+        );
+
+        // Act & Assert
+        assertEquals("Parent shard ID should match the one set", parentShardId, shardWithParent.getParentShardId());
+        assertNull("Parent shard ID should be null when not set", shardWithoutParent.getParentShardId());
+    }
+
+    /**
+    * Test case for getRecoveringChildShards method
+    *
+    * This test verifies that the getRecoveringChildShards method correctly returns
+    * the recovering child shards without creating a defensive copy.
+    */
+    public void test_getRecoveringChildShards_1() {
+        // Arrange
+        ShardId parentShardId = new ShardId("test_index", "_na_", 0);
+        String currentNodeId = "node1";
+        boolean primary = true;
+        ShardRoutingState state = ShardRoutingState.SPLITTING;
+        AllocationId allocationId = AllocationId.newInitializing();
+
+        ShardRouting[] childShards = new ShardRouting[] {
+            TestShardRouting.newShardRouting(new ShardId("test_index", "_na_", 1), null, true, ShardRoutingState.UNASSIGNED),
+            TestShardRouting.newShardRouting(new ShardId("test_index", "_na_", 2), null, false, ShardRoutingState.UNASSIGNED)
+        };
+
+        ShardRouting parentShard = new ShardRouting(
+            parentShardId,
+            currentNodeId,
+            null,
+            primary,
+            false,
+            state,
+            null,
+            null,
+            allocationId,
+            UNAVAILABLE_EXPECTED_SHARD_SIZE,
+            childShards,
+            null
+        );
+
+        // Act
+        ShardRouting[] result = parentShard.getRecoveringChildShards();
+
+        // Assert
+        assertNotNull("Returned array should not be null", result);
+        assertSame("Returned array should be the same instance as the original", childShards, result);
+        assertEquals("Returned array should have the correct number of child shards", 2, result.length);
+
+        // Verify that modifying the returned array affects the original
+        result[0] = null;
+        assertNull("Modifying the returned array should affect the original", childShards[0]);
+    }
+
+    /**
+    * Test case for public boolean isStartedChildReplica()
+    *
+    * This test verifies that isStartedChildReplica() returns true when:
+    * - The shard is not primary (primary == false)
+    * - The shard has a parent shard ID (getParentShardId() != null)
+    * - The shard is in started state (started() == true)
+    */
+    public void test_isStartedChildReplica_1() {
+        // Arrange
+        ShardId parentShardId = new ShardId("test_index", "_na_", 0);
+        ShardId childShardId = new ShardId("test_index", "_na_", 1);
+        String nodeId = "node1";
+        boolean primary = false;
+        boolean searchOnly = false;
+        ShardRoutingState state = ShardRoutingState.STARTED;
+        AllocationId allocationId = AllocationId.newInitializing();
+
+        ShardRouting childReplica = new ShardRouting(
+            childShardId,
+            nodeId,
+            null,
+            primary,
+            searchOnly,
+            state,
+            null,
+            null,
+            allocationId,
+            UNAVAILABLE_EXPECTED_SHARD_SIZE,
+            null,
+            parentShardId
+        );
+
+        // Act
+        boolean result = childReplica.isStartedChildReplica();
+
+        // Assert
+        assertTrue("The shard should be identified as a started child replica", result);
+        assertFalse("The shard should not be primary", childReplica.primary());
+        assertNotNull("The shard should have a parent shard ID", childReplica.getParentShardId());
+        assertTrue("The shard should be in started state", childReplica.started());
+    }
+
+    /**
+    * Negative test case for public boolean isStartedChildReplica()
+    *
+    * This test verifies that isStartedChildReplica() returns false when any of the conditions are not met:
+    * - The shard is primary
+    * - The shard doesn't have a parent shard ID
+    * - The shard is not in started state
+    */
+    public void test_isStartedChildReplica_negative() {
+        ShardId shardId = new ShardId("test_index", "_na_", 1);
+        String nodeId = "node1";
+        AllocationId allocationId = AllocationId.newInitializing();
+
+        // Case 1: Primary shard
+        ShardRouting primaryShard = new ShardRouting(
+            shardId,
+            nodeId,
+            null,
+            true,
+            false,
+            ShardRoutingState.STARTED,
+            null,
+            null,
+            allocationId,
+            UNAVAILABLE_EXPECTED_SHARD_SIZE,
+            null,
+            new ShardId("test_index", "_na_", 0)
+        );
+        assertFalse("Primary shard should not be identified as a started child replica", primaryShard.isStartedChildReplica());
+
+        // Case 2: No parent shard ID
+        ShardRouting noParentShard = new ShardRouting(
+            shardId,
+            nodeId,
+            null,
+            false,
+            false,
+            ShardRoutingState.STARTED,
+            null,
+            null,
+            allocationId,
+            UNAVAILABLE_EXPECTED_SHARD_SIZE,
+            null,
+            null
+        );
+        assertFalse("Shard without parent should not be identified as a started child replica", noParentShard.isStartedChildReplica());
+
+        // Case 3: Not in started state
+        ShardRouting notStartedShard = new ShardRouting(
+            shardId,
+            nodeId,
+            null,
+            true,
+            false,
+            ShardRoutingState.INITIALIZING,
+            RecoverySource.ExistingStoreRecoverySource.INSTANCE,
+            null,
+            allocationId,
+            UNAVAILABLE_EXPECTED_SHARD_SIZE,
+            null,
+            new ShardId("test_index", "_na_", 0)
+        );
+        assertFalse("Non-started shard should not be identified as a started child replica", notStartedShard.isStartedChildReplica());
+    }
+
+    /**
+     * Negative test cases for `isStartedChildReplica`
+     */
+    public void test_isStartedChildReplica_negative_cases() {
+        // Test case 1: Primary shard
+        ShardRouting primaryShard = TestShardRouting.newShardRouting("test", 0, "node1", true, ShardRoutingState.STARTED);
+        assertFalse("Primary shard should not be a started child replica", primaryShard.isStartedChildReplica());
+
+        // Test case 2: Unassigned shard
+        ShardRouting unassignedShard = ShardRouting.newUnassigned(
+            new ShardId("test", "_na_", 0),
+            false,
+            RecoverySource.PeerRecoverySource.INSTANCE,
+            new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "test")
+        );
+        assertFalse("Unassigned shard should not be a started child replica", unassignedShard.isStartedChildReplica());
+
+        // Test case 3: Initializing shard
+        ShardRouting initializingShard = TestShardRouting.newShardRouting("test", 0, "node1", false, ShardRoutingState.INITIALIZING);
+        assertFalse("Initializing shard should not be a started child replica", initializingShard.isStartedChildReplica());
+
+        // Test case 4: Relocating shard
+        ShardRouting relocatingShard = TestShardRouting.newShardRouting("test", 0, "node1", "node2", false, ShardRoutingState.RELOCATING);
+        assertFalse("Relocating shard should not be a started child replica", relocatingShard.isStartedChildReplica());
+
+        // Test case 5: Started shard without parent
+        ShardRouting startedShardWithoutParent = TestShardRouting.newShardRouting("test", 0, "node1", false, ShardRoutingState.STARTED);
+        assertFalse("Started shard without parent should not be a started child replica", startedShardWithoutParent.isStartedChildReplica());
+
+        // Test case 6: Started primary child shard
+        ShardId parentShardId = new ShardId("test", "_na_", 0);
+        ShardRouting startedPrimaryChildShard = new ShardRouting(
+            new ShardId("test", "_na_", 1),
+            "node1",
+            null,
+            true,
+            false,
+            ShardRoutingState.STARTED,
+            null,
+            null,
+            AllocationId.newInitializing(),
+            UNAVAILABLE_EXPECTED_SHARD_SIZE,
+            null,
+            parentShardId
+        );
+        assertFalse("Started primary child shard should not be a started child replica", startedPrimaryChildShard.isStartedChildReplica());
+
+    }
+
+    /**
+    * Test case for unassignedReasonChildShardCreated method
+    * Path constraints: (unassignedInfo != null)
+    * Expected result: unassignedInfo.getReason() == UnassignedInfo.Reason.CHILD_SHARD_CREATED
+    */
+    public void test_unassignedReasonChildShardCreated_1() {
+        // Arrange
+        ShardId shardId = new ShardId("test_index", "_na_", 0);
+        UnassignedInfo unassignedInfo = new UnassignedInfo(UnassignedInfo.Reason.CHILD_SHARD_CREATED, "Test reason");
+        ShardRouting shardRouting = ShardRouting.newUnassigned(
+            shardId,
+            true,
+            RecoverySource.EmptyStoreRecoverySource.INSTANCE,
+            unassignedInfo
+        );
+
+        // Act
+        boolean result = shardRouting.unassignedReasonChildShardCreated();
+
+        // Assert
+        assertTrue("Expected unassignedReasonChildShardCreated to return true for CHILD_SHARD_CREATED reason", result);
+    }
+
+    /**
+    * Test case for unassignedReasonChildShardCreated method
+    * Path constraints: (unassignedInfo != null)
+    * Expected result: unassignedInfo.getReason() != UnassignedInfo.Reason.CHILD_SHARD_CREATED
+    */
+    public void test_unassignedReasonChildShardCreated_2() {
+        // Arrange
+        ShardId shardId = new ShardId("test_index", "_na_", 0);
+        UnassignedInfo unassignedInfo = new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "Test reason");
+        ShardRouting shardRouting = ShardRouting.newUnassigned(
+            shardId,
+            true,
+            RecoverySource.EmptyStoreRecoverySource.INSTANCE,
+            unassignedInfo
+        );
+
+        // Act
+        boolean result = shardRouting.unassignedReasonChildShardCreated();
+
+        // Assert
+        assertFalse("Expected unassignedReasonChildShardCreated to return false for non-CHILD_SHARD_CREATED reason", result);
+    }
+
+    /**
+    * Test case for unassignedReasonChildShardCreated method
+    * Path constraints: (unassignedInfo == null)
+    * Expected result: false
+    */
+    public void test_unassignedReasonChildShardCreated_3() {
+        // Arrange
+        ShardId shardId = new ShardId("test_index", "_na_", 0);
+        ShardRouting shardRouting = TestShardRouting.newShardRouting(shardId, "node1", true, ShardRoutingState.STARTED);
+
+        // Act
+        boolean result = shardRouting.unassignedReasonChildShardCreated();
+
+        // Assert
+        assertFalse("Expected unassignedReasonChildShardCreated to return false when unassignedInfo is null", result);
+    }
+
+    /**
+     * Negative test cases for `unassignedReasonChildShardCreated`
+     */
+    public void test_unassignedReasonChildShardCreated_negative_tests() {
+        // Test when unassignedInfo is null
+        ShardRouting shardWithNullUnassignedInfo = TestShardRouting.newShardRouting("test", 0, "node1", true, ShardRoutingState.STARTED);
+        assertFalse("Should return false when unassignedInfo is null", shardWithNullUnassignedInfo.unassignedReasonChildShardCreated());
+
+        // Test when shard is not in UNASSIGNED state
+        ShardRouting assignedShard = TestShardRouting.newShardRouting("test", 0, "node1", true, ShardRoutingState.STARTED);
+        assertFalse("Should return false when shard is not UNASSIGNED", assignedShard.unassignedReasonChildShardCreated());
+
+        // Test when unassigned reason is not CHILD_SHARD_CREATED
+        UnassignedInfo unassignedInfo = new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "test reason");
+        ShardRouting shardWithDifferentReason = ShardRouting.newUnassigned(
+            new ShardId("test", "_na_", 0),
+            true,
+            RecoverySource.EmptyStoreRecoverySource.INSTANCE,
+            unassignedInfo
+        );
+        assertFalse("Should return false when reason is not CHILD_SHARD_CREATED", shardWithDifferentReason.unassignedReasonChildShardCreated());
+
+    }
+
+    /**
+     * Positive test case for `unassignedReasonChildShardCreated`
+     */
+    public void test_unassignedReasonChildShardCreated_positive_test() {
+        UnassignedInfo childShardCreatedInfo = new UnassignedInfo(UnassignedInfo.Reason.CHILD_SHARD_CREATED, "child shard created");
+        ShardRouting childShard = ShardRouting.newUnassigned(
+            new ShardId("test", "_na_", 1),
+            false,
+            RecoverySource.PeerRecoverySource.INSTANCE,
+            childShardCreatedInfo
+        );
+        assertTrue("Should return true for CHILD_SHARD_CREATED reason", childShard.unassignedReasonChildShardCreated());
+    }
+
+    /**
+     * Test case for isSplitTargetOf method
+     * This test verifies that a shard is correctly identified as a split target of another shard
+     */
+    public void testIsSplitTargetOf() {
+        // Arrange
+        ShardId parentShardId = new ShardId("test_index", "_na_", 0);
+        ShardId childShardId = new ShardId("test_index", "_na_", 1);
+
+        AllocationId parentAllocationId = AllocationId.newInitializing();
+        parentAllocationId = AllocationId.newSplit(parentAllocationId, 2);
+        String firstChildId = parentAllocationId.getSplitChildAllocationIds().iterator().next();
+        AllocationId childAllocationId = AllocationId.newInitializing(firstChildId);
+        childAllocationId = AllocationId.newTargetSplit(parentAllocationId, childAllocationId.getId());
+
+        ShardRouting parentShard = new ShardRouting(
+            parentShardId,
+            "node1",
+            null,
+            true,
+            false,
+            ShardRoutingState.SPLITTING,
+            null,
+            null,
+            parentAllocationId,
+            0,
+            null,
+            null
+        );
+
+        ShardRouting childShard = new ShardRouting(
+            childShardId,
+            null,
+            null,
+            false,
+            false,
+            ShardRoutingState.UNASSIGNED,
+            RecoverySource.InPlaceShardSplitRecoverySource.INSTANCE,
+            new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "test"),
+            childAllocationId,
+            UNAVAILABLE_EXPECTED_SHARD_SIZE,
+            null,
+            parentShardId
+        );
+
+        // Act
+        boolean result = childShard.isSplitTargetOf(parentShard);
+
+        // Assert
+        assertTrue("Child shard should be identified as split target of parent shard", result);
+        assertEquals("Parent shard should be in SPLITTING state", ShardRoutingState.SPLITTING, parentShard.state());
+        assertTrue("Parent shard should be primary", parentShard.primary());
+        assertNotNull("Parent shard's split child allocation IDs should not be null", parentShard.allocationId().getSplitChildAllocationIds());
+        assertTrue("Parent shard's split child allocation IDs should contain child's allocation ID",
+            parentShard.allocationId().getSplitChildAllocationIds().contains(childShard.allocationId().getId()));
+        assertEquals("Child shard's parent shard ID should match parent's shard ID", parentShardId, childShard.getParentShardId());
+    }
+
+    /**
+     * Negative test cases for `isSplitTargetOf`
+     */
+    public void test_isSplitTargetOf_negative_cases() {
+        ShardId parentShardId = new ShardId("test_index", "_na_", 0);
+        ShardId childShardId = new ShardId("test_index", "_na_", 1);
+
+        // Setup a parent shard
+        ShardRouting parentShard = TestShardRouting.newShardRouting(parentShardId, "node1", true, ShardRoutingState.SPLITTING);
+        parentShard = new ShardRouting(
+            parentShardId,
+            parentShard.currentNodeId(),
+            null,
+            parentShard.primary(),
+            parentShard.isSearchOnly(),
+            parentShard.state(),
+            null,
+            null,
+            AllocationId.newSplit(AllocationId.newInitializing(), 2),
+            0,
+            null,
+            null
+        );
+
+        // Setup a child shard
+        ShardRouting childShard = TestShardRouting.newShardRouting(childShardId, null, false, ShardRoutingState.UNASSIGNED);
+        childShard = new ShardRouting(
+            childShardId,
+            null,
+            null,
+            childShard.primary(),
+            childShard.isSearchOnly(),
+            childShard.state(),
+            RecoverySource.InPlaceShardSplitRecoverySource.INSTANCE,
+            new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "test"),
+            AllocationId.newInitializing(parentShard.allocationId().getId()),
+            UNAVAILABLE_EXPECTED_SHARD_SIZE,
+            null,
+            parentShardId
+        );
+
+        // Test case 2: Parent shard is not in SPLITTING state
+        ShardRouting nonSplittingParent = TestShardRouting.newShardRouting(parentShardId, "node1", true, ShardRoutingState.STARTED);
+        assertFalse("Should return false when parent is not in SPLITTING state", childShard.isSplitTargetOf(nonSplittingParent));
+
+        // Test case 3: Child shard has no parent allocation ID
+        ShardRouting childWithNoParent = new ShardRouting(
+            childShardId,
+            null,
+            null,
+            false,
+            false,
+            ShardRoutingState.UNASSIGNED,
+            RecoverySource.InPlaceShardSplitRecoverySource.INSTANCE,
+            new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "test"),
+            AllocationId.newInitializing(),
+            UNAVAILABLE_EXPECTED_SHARD_SIZE,
+            null,
+            parentShardId
+        );
+        assertFalse("Should return false when child has no parent allocation ID", childWithNoParent.isSplitTargetOf(parentShard));
+
+        // Test case 4: Parent shard has no allocation ID
+        ShardRouting parentWithNoAllocationId = TestShardRouting.newShardRouting(parentShardId, "node1", true, ShardRoutingState.SPLITTING);
+        assertFalse("Should return false when parent has no allocation ID", childShard.isSplitTargetOf(parentWithNoAllocationId));
+
+        // Test case 5: Parent and child allocation IDs don't match
+        ShardRouting childWithDifferentParent = new ShardRouting(
+            childShardId,
+            null,
+            null,
+            false,
+            false,
+            ShardRoutingState.UNASSIGNED,
+            RecoverySource.InPlaceShardSplitRecoverySource.INSTANCE,
+            new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "test"),
+            AllocationId.newInitializing("different_parent_id"),
+            UNAVAILABLE_EXPECTED_SHARD_SIZE,
+            null,
+            parentShardId
+        );
+        assertFalse("Should return false when parent and child allocation IDs don't match", childWithDifferentParent.isSplitTargetOf(parentShard));
+
+        // Test case 6: Child shard ID doesn't match parent's split child IDs
+        ShardId differentChildShardId = new ShardId("test_index", "_na_", 2);
+        ShardRouting differentChildShard = new ShardRouting(
+            differentChildShardId,
+            null,
+            null,
+            false,
+            false,
+            ShardRoutingState.UNASSIGNED,
+            RecoverySource.InPlaceShardSplitRecoverySource.INSTANCE,
+            new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "test"),
+            AllocationId.newInitializing(parentShard.allocationId().getId()),
+            UNAVAILABLE_EXPECTED_SHARD_SIZE,
+            null,
+            parentShardId
+        );
+        assertFalse("Should return false when child shard ID doesn't match parent's split child IDs", differentChildShard.isSplitTargetOf(parentShard));
+
+        // Test case 7: Child's parent shard ID doesn't match parent's shard ID
+        ShardId differentParentShardId = new ShardId("test_index", "_na_", 3);
+        ShardRouting childWithDifferentParentId = new ShardRouting(
+            childShardId,
+            null,
+            null,
+            false,
+            false,
+            ShardRoutingState.UNASSIGNED,
+            RecoverySource.InPlaceShardSplitRecoverySource.INSTANCE,
+            new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "test"),
+            AllocationId.newInitializing(parentShard.allocationId().getId()),
+            UNAVAILABLE_EXPECTED_SHARD_SIZE,
+            null,
+            differentParentShardId
+        );
+        assertFalse("Should return false when child's parent shard ID doesn't match parent's shard ID", childWithDifferentParentId.isSplitTargetOf(parentShard));
+
+        // Test case 8: Parent is not primary
+        ShardRouting nonPrimaryParent = TestShardRouting.newShardRouting(parentShardId, "node1", false, ShardRoutingState.SPLITTING);
+        assertFalse("Should return false when parent is not primary", childShard.isSplitTargetOf(nonPrimaryParent));
+    }
+
+    /**
+     * Test case for isSplitTarget method
+     *
+     * This test verifies that isSplitTarget returns true when the shard has a parent shard ID,
+     * and false when it doesn't.
+     */
+    public void test_isSplitTarget() {
+        // Arrange
+        ShardId parentShardId = new ShardId("test_index", "_na_", 0);
+        ShardId childShardId = new ShardId("test_index", "_na_", 1);
+
+        // Create a shard routing with a parent shard ID (split target)
+        ShardRouting splitTargetShard = new ShardRouting(
+            childShardId,
+            "node1",
+            null,
+            false,
+            false,
+            ShardRoutingState.INITIALIZING,
+            RecoverySource.PeerRecoverySource.INSTANCE,
+            null,
+            AllocationId.newInitializing(),
+            0,
+            null,
+            parentShardId
+        );
+
+        // Create a shard routing without a parent shard ID (not a split target)
+        ShardRouting nonSplitTargetShard = new ShardRouting(
+            childShardId,
+            "node1",
+            null,
+            false,
+            false,
+            ShardRoutingState.STARTED,
+            null,
+            null,
+            AllocationId.newInitializing(),
+            UNAVAILABLE_EXPECTED_SHARD_SIZE,
+            null,
+            null
+        );
+
+        // Act & Assert
+        assertTrue("Shard with parent ID should be identified as split target", splitTargetShard.isSplitTarget());
+        assertFalse("Shard without parent ID should not be identified as split target", nonSplitTargetShard.isSplitTarget());
+    }
+
+    /**
+    * Negative test cases for `isSplitTarget`
+    * Generate a test for each of the following scenarios relevant for `isSplitTarget`:
+    * 1. input is empty and/or invalid;
+    * 2. input is outside accepted bounds;
+    * 3. input is incorrect type and/or input is incorrect format;
+    * 4. exceptions are tested;
+    * 5. other edge cases for `isSplitTarget` are tested
+    */
+    public void test_isSplitTarget_negative_cases() {
+        // 1. Test with null ShardRouting
+        assertThrows(NullPointerException.class, () -> {
+            ShardRouting nullShard = null;
+            nullShard.isSplitTarget();
+        });
+
+        // 2. Test with unassigned shard (outside accepted bounds)
+        ShardRouting unassignedShard = ShardRouting.newUnassigned(
+            new ShardId("test", "_na_", 0),
+            true,
+            RecoverySource.EmptyStoreRecoverySource.INSTANCE,
+            new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "test")
+        );
+        assertFalse("Unassigned shard should not be a split target", unassignedShard.isSplitTarget());
+
+        // 3. Test with incorrect state (not INITIALIZING)
+        ShardRouting startedShard = TestShardRouting.newShardRouting("test", 0, "node1", true, ShardRoutingState.STARTED);
+        assertFalse("Started shard should not be a split target", startedShard.isSplitTarget());
+
+        // 4. Test exception handling (no exception should be thrown, but method should return false)
+        ShardRouting relocatingShard = TestShardRouting.newShardRouting("test", 0, "node1", "node2", true, ShardRoutingState.RELOCATING);
+        assertFalse("Relocating shard should not be a split target", relocatingShard.isSplitTarget());
+
+        // 5. Edge case: Initializing shard without parent
+        ShardRouting initializingShardNoParent = TestShardRouting.newShardRouting("test", 0, "node1", true, ShardRoutingState.INITIALIZING);
+        assertFalse("Initializing shard without parent should not be a split target", initializingShardNoParent.isSplitTarget());
+    }
+
+    /**
+     * Test case for isSplitSourceOf method
+     * This test verifies that a shard is correctly identified as a split source of another shard
+     */
+    public void testIsSplitSourceOf() {
+        // Arrange
+        ShardId parentShardId = new ShardId("test_index", "_na_", 0);
+        ShardId childShardId = new ShardId("test_index", "_na_", 1);
+
+        AllocationId parentAllocationId = AllocationId.newInitializing();
+        parentAllocationId = AllocationId.newSplit(parentAllocationId, 2);
+        String firstChildId = parentAllocationId.getSplitChildAllocationIds().iterator().next();
+        AllocationId childAllocationId = AllocationId.newInitializing(firstChildId);
+        childAllocationId = AllocationId.newTargetSplit(parentAllocationId, childAllocationId.getId());
+
+        ShardRouting parentShard = new ShardRouting(
+            parentShardId,
+            "node1",
+            null,
+            true,
+            false,
+            ShardRoutingState.SPLITTING,
+            null,
+            null,
+            parentAllocationId,
+            0,
+            null,
+            null
+        );
+
+        ShardRouting childShard = new ShardRouting(
+            childShardId,
+            null,
+            null,
+            false,
+            false,
+            ShardRoutingState.UNASSIGNED,
+            RecoverySource.InPlaceShardSplitRecoverySource.INSTANCE,
+            new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "test"),
+            childAllocationId,
+            UNAVAILABLE_EXPECTED_SHARD_SIZE,
+            null,
+            parentShardId
+        );
+
+        // Act
+        boolean result = parentShard.isSplitSourceOf(childShard);
+
+        // Assert
+        assertTrue("Parent shard should be identified as split source of child shard", result);
+        assertEquals("Parent shard should be in SPLITTING state", ShardRoutingState.SPLITTING, parentShard.state());
+        assertTrue("Parent shard should be primary", parentShard.primary());
+        assertNotNull("Parent shard's split child allocation IDs should not be null", parentShard.allocationId().getSplitChildAllocationIds());
+        assertTrue("Parent shard's split child allocation IDs should contain child's allocation ID", parentShard.allocationId().getSplitChildAllocationIds().contains(childShard.allocationId().getId()));
+        assertEquals("Child shard's parent shard ID should match parent's shard ID", parentShardId, childShard.getParentShardId());
+    }
+
+    /**
+     * Negative test cases for `isSplitSourceOf`
+     */
+    public void test_isSplitSourceOf_negative_cases() {
+        ShardId parentShardId = new ShardId("test_index", "_na_", 0);
+        ShardId childShardId = new ShardId("test_index", "_na_", 1);
+
+        // Setup a parent shard
+        ShardRouting parentShard = TestShardRouting.newShardRouting(parentShardId, "node1", true, ShardRoutingState.SPLITTING);
+        parentShard = new ShardRouting(
+            parentShardId,
+            parentShard.currentNodeId(),
+            null,
+            parentShard.primary(),
+            parentShard.isSearchOnly(),
+            parentShard.state(),
+            null,
+            null,
+            AllocationId.newSplit(AllocationId.newInitializing(), 2),
+            0,
+            null,
+            null
+        );
+
+        // Setup a child shard
+        ShardRouting childShard = TestShardRouting.newShardRouting(childShardId, null, false, ShardRoutingState.UNASSIGNED);
+        childShard = new ShardRouting(
+            childShardId,
+            null,
+            null,
+            childShard.primary(),
+            childShard.isSearchOnly(),
+            childShard.state(),
+            RecoverySource.InPlaceShardSplitRecoverySource.INSTANCE,
+            new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "test"),
+            AllocationId.newInitializing(parentShard.allocationId().getId()),
+            UNAVAILABLE_EXPECTED_SHARD_SIZE,
+            null,
+            parentShardId
+        );
+
+        // 2. Test when parent shard is not in SPLITTING state
+        ShardRouting nonSplittingParent = TestShardRouting.newShardRouting(parentShardId, "node1", true, ShardRoutingState.STARTED);
+        assertFalse("Should return false when parent is not in SPLITTING state", nonSplittingParent.isSplitSourceOf(childShard));
+
+        // 3. Test when child shard has no parent allocation ID
+        ShardRouting childWithNoParent = new ShardRouting(
+            childShardId,
+            null,
+            null,
+            false,
+            false,
+            ShardRoutingState.UNASSIGNED,
+            RecoverySource.InPlaceShardSplitRecoverySource.INSTANCE,
+            new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "test"),
+            AllocationId.newInitializing(),
+            UNAVAILABLE_EXPECTED_SHARD_SIZE,
+            null,
+            parentShardId
+        );
+        assertFalse("Should return false when child has no parent allocation ID", parentShard.isSplitSourceOf(childWithNoParent));
+
+        // 4. Test when parent shard has no allocation ID
+        ShardRouting parentWithNoAllocationId = TestShardRouting.newShardRouting(parentShardId, "node1", true, ShardRoutingState.SPLITTING);
+        assertFalse("Should return false when parent has no allocation ID", parentWithNoAllocationId.isSplitSourceOf(childShard));
+
+        // 5. Test when parent and child allocation IDs don't match
+        ShardRouting childWithDifferentParent = new ShardRouting(
+            childShardId,
+            null,
+            null,
+            false,
+            false,
+            ShardRoutingState.UNASSIGNED,
+            RecoverySource.InPlaceShardSplitRecoverySource.INSTANCE,
+            new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "test"),
+            AllocationId.newInitializing("different_parent_id"),
+            UNAVAILABLE_EXPECTED_SHARD_SIZE,
+            null,
+            parentShardId
+        );
+        assertFalse("Should return false when parent and child allocation IDs don't match", parentShard.isSplitSourceOf(childWithDifferentParent));
+
+        // 6. Test when child shard ID doesn't match parent's split child IDs
+        ShardId differentChildShardId = new ShardId("test_index", "_na_", 2);
+        ShardRouting differentChildShard = new ShardRouting(
+            differentChildShardId,
+            null,
+            null,
+            false,
+            false,
+            ShardRoutingState.UNASSIGNED,
+            RecoverySource.InPlaceShardSplitRecoverySource.INSTANCE,
+            new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "test"),
+            AllocationId.newInitializing(parentShard.allocationId().getId()),
+            UNAVAILABLE_EXPECTED_SHARD_SIZE,
+            null,
+            parentShardId
+        );
+        assertFalse("Should return false when child shard ID doesn't match parent's split child IDs", parentShard.isSplitSourceOf(differentChildShard));
+
+        // 7. Test when child's parent shard ID doesn't match parent's shard ID
+        ShardId differentParentShardId = new ShardId("test_index", "_na_", 3);
+        ShardRouting childWithDifferentParentId = new ShardRouting(
+            childShardId,
+            null,
+            null,
+            false,
+            false,
+            ShardRoutingState.UNASSIGNED,
+            RecoverySource.InPlaceShardSplitRecoverySource.INSTANCE,
+            new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "test"),
+            AllocationId.newInitializing(parentShard.allocationId().getId()),
+            UNAVAILABLE_EXPECTED_SHARD_SIZE,
+            null,
+            differentParentShardId
+        );
+        assertFalse("Should return false when child's parent shard ID doesn't match parent's shard ID", parentShard.isSplitSourceOf(childWithDifferentParentId));
+
+        // 8. Test when parent is not primary
+        ShardRouting nonPrimaryParent = TestShardRouting.newShardRouting(parentShardId, "node1", false, ShardRoutingState.SPLITTING);
+        assertFalse("Should return false when parent is not primary", nonPrimaryParent.isSplitSourceOf(childShard));
     }
 }

--- a/server/src/test/java/org/opensearch/plugins/PluginsServiceTests.java
+++ b/server/src/test/java/org/opensearch/plugins/PluginsServiceTests.java
@@ -36,12 +36,17 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.Constants;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.opensearch.LegacyESVersion;
 import org.opensearch.Version;
 import org.opensearch.bootstrap.JarHell;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.io.PathUtils;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.core.index.Index;
 import org.opensearch.env.Environment;
 import org.opensearch.env.TestEnvironment;
 import org.opensearch.index.IndexModule;
@@ -57,15 +62,8 @@ import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
+import java.util.function.Predicate;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
@@ -77,6 +75,15 @@ import static org.hamcrest.Matchers.hasToString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.*;
 
 @LuceneTestCase.SuppressFileSystems(value = "ExtrasFS")
 public class PluginsServiceTests extends OpenSearchTestCase {
@@ -90,1059 +97,1078 @@ public class PluginsServiceTests extends OpenSearchTestCase {
         }
     }
 
-    public static class AdditionalSettingsPlugin2 extends Plugin {
+     public static class AdditionalSettingsPlugin2 extends Plugin {
+         @Override
+         public Settings additionalSettings() {
+             return Settings.builder().put("foo.bar", "2").build();
+         }
+     }
+
+    public static class ShardSplitNotAllowedPlugin extends Plugin {
         @Override
-        public Settings additionalSettings() {
-            return Settings.builder().put("foo.bar", "2").build();
+        public Predicate<Index> shardSplitAllowedPredicate() {
+            return (index) -> false;
         }
     }
 
-    public static class FilterablePlugin extends Plugin implements ScriptPlugin {}
+    public static class ShardSplitAllowedPlugin extends Plugin {}
 
-    static PluginsService newPluginsService(Settings settings, Class<? extends Plugin>... classpathPlugins) {
+     public static class FilterablePlugin extends Plugin implements ScriptPlugin {}
+
+     static PluginsService newPluginsService(Settings settings, Class<? extends Plugin>... classpathPlugins) {
+         return new PluginsService(
+             settings,
+             null,
+             null,
+             TestEnvironment.newEnvironment(settings).pluginsDir(),
+             Arrays.asList(classpathPlugins)
+         );
+     }
+
+    static PluginsService newPluginsServiceSplit(Settings settings, Class<? extends Plugin>... classpathPlugins) {
         return new PluginsService(
             settings,
             null,
             null,
-            TestEnvironment.newEnvironment(settings).pluginsDir(),
+            null,
             Arrays.asList(classpathPlugins)
         );
     }
 
-    public void testAdditionalSettings() {
-        Settings settings = Settings.builder()
-            .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir())
-            .put("my.setting", "test")
-            .put(IndexModule.INDEX_STORE_TYPE_SETTING.getKey(), IndexModule.Type.NIOFS.getSettingsKey())
-            .build();
-        PluginsService service = newPluginsService(settings, AdditionalSettingsPlugin1.class);
-        Settings newSettings = service.updatedSettings();
-        assertEquals("test", newSettings.get("my.setting")); // previous settings still exist
-        assertEquals("1", newSettings.get("foo.bar")); // added setting exists
-        // does not override pre existing settings
-        assertEquals(IndexModule.Type.NIOFS.getSettingsKey(), newSettings.get(IndexModule.INDEX_STORE_TYPE_SETTING.getKey()));
-    }
-
-    public void testAdditionalSettingsClash() {
-        Settings settings = Settings.builder().put(Environment.PATH_HOME_SETTING.getKey(), createTempDir()).build();
-        PluginsService service = newPluginsService(settings, AdditionalSettingsPlugin1.class, AdditionalSettingsPlugin2.class);
-        try {
-            service.updatedSettings();
-            fail("Expected exception when building updated settings");
-        } catch (IllegalArgumentException e) {
-            String msg = e.getMessage();
-            assertTrue(msg, msg.contains("Cannot have additional setting [foo.bar]"));
-            assertTrue(msg, msg.contains("plugin [" + AdditionalSettingsPlugin1.class.getName()));
-            assertTrue(msg, msg.contains("plugin [" + AdditionalSettingsPlugin2.class.getName()));
-        }
-    }
-
-    public void testExistingPluginMissingDescriptor() throws Exception {
-        Path pluginsDir = createTempDir();
-        Files.createDirectory(pluginsDir.resolve("plugin-missing-descriptor"));
-        IllegalStateException e = expectThrows(IllegalStateException.class, () -> PluginsService.getPluginBundles(pluginsDir));
-        assertThat(e.getMessage(), containsString("Could not load plugin descriptor for plugin directory [plugin-missing-descriptor]"));
-    }
-
-    public void testFilterPlugins() {
-        Settings settings = Settings.builder()
-            .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir())
-            .put("my.setting", "test")
-            .put(IndexModule.INDEX_STORE_TYPE_SETTING.getKey(), IndexModule.Type.NIOFS.getSettingsKey())
-            .build();
-        PluginsService service = newPluginsService(settings, AdditionalSettingsPlugin1.class, FilterablePlugin.class);
-        List<ScriptPlugin> scriptPlugins = service.filterPlugins(ScriptPlugin.class);
-        assertEquals(1, scriptPlugins.size());
-        assertEquals(FilterablePlugin.class, scriptPlugins.get(0).getClass());
-    }
-
-    public void testHiddenDirectories() throws IOException {
-        final Path home = createTempDir();
-        final Settings settings = Settings.builder().put(Environment.PATH_HOME_SETTING.getKey(), home).build();
-        final Path hidden = home.resolve("plugins").resolve(".hidden");
-        Files.createDirectories(hidden);
-        @SuppressWarnings("unchecked")
-        final IllegalStateException e = expectThrows(IllegalStateException.class, () -> newPluginsService(settings));
-        final String expected = "Could not load plugin descriptor for plugin directory [.hidden]";
-        assertThat(e, hasToString(containsString(expected)));
-    }
-
-    public void testStartupWithRemovingMarker() throws IOException {
-        final Path home = createTempDir();
-        final Settings settings = Settings.builder().put(Environment.PATH_HOME_SETTING.getKey(), home).build();
-        final Path fake = home.resolve("plugins").resolve("fake");
-        Files.createDirectories(fake);
-        Files.createFile(fake.resolve("plugin.jar"));
-        final Path removing = home.resolve("plugins").resolve(".removing-fake");
-        Files.createFile(removing);
-        PluginTestUtil.writePluginProperties(
-            fake,
-            "description",
-            "fake",
-            "name",
-            "fake",
-            "version",
-            "1.0.0",
-            "opensearch.version",
-            Version.CURRENT.toString(),
-            "java.version",
-            System.getProperty("java.specification.version"),
-            "classname",
-            "Fake",
-            "has.native.controller",
-            "false"
-        );
-        final IllegalStateException e = expectThrows(IllegalStateException.class, () -> newPluginsService(settings));
-        final String expected = String.format(
-            Locale.ROOT,
-            "found file [%s] from a failed attempt to remove the plugin [fake]; execute [opensearch-plugin remove fake]",
-            removing
-        );
-        assertThat(e, hasToString(containsString(expected)));
-    }
-
-    public void testLoadPluginWithNoPublicConstructor() {
-        class NoPublicConstructorPlugin extends Plugin {
-
-            private NoPublicConstructorPlugin() {
-
-            }
-
-        }
-
-        final Path home = createTempDir();
-        final Settings settings = Settings.builder().put(Environment.PATH_HOME_SETTING.getKey(), home).build();
-        final IllegalStateException e = expectThrows(
-            IllegalStateException.class,
-            () -> newPluginsService(settings, NoPublicConstructorPlugin.class)
-        );
-        assertThat(e, hasToString(containsString("no public constructor")));
-    }
-
-    public void testLoadPluginWithMultiplePublicConstructors() {
-        class MultiplePublicConstructorsPlugin extends Plugin {
-
-            @SuppressWarnings("unused")
-            public MultiplePublicConstructorsPlugin() {
-
-            }
-
-            @SuppressWarnings("unused")
-            public MultiplePublicConstructorsPlugin(final Settings settings) {
-
-            }
-
-        }
-
-        final Path home = createTempDir();
-        final Settings settings = Settings.builder().put(Environment.PATH_HOME_SETTING.getKey(), home).build();
-        final IllegalStateException e = expectThrows(
-            IllegalStateException.class,
-            () -> newPluginsService(settings, MultiplePublicConstructorsPlugin.class)
-        );
-        assertThat(e, hasToString(containsString("no unique public constructor")));
-    }
-
-    public void testLoadPluginWithNoPublicConstructorOfCorrectSignature() {
-        class TooManyParametersPlugin extends Plugin {
-
-            @SuppressWarnings("unused")
-            public TooManyParametersPlugin(Settings settings, Path configPath, Object object) {
-
-            }
-
-        }
-
-        class TwoParametersFirstIncorrectType extends Plugin {
-
-            @SuppressWarnings("unused")
-            public TwoParametersFirstIncorrectType(Object object, Path configPath) {
-
-            }
-        }
-
-        class TwoParametersSecondIncorrectType extends Plugin {
-
-            @SuppressWarnings("unused")
-            public TwoParametersSecondIncorrectType(Settings settings, Object object) {
-
-            }
-
-        }
-
-        class OneParameterIncorrectType extends Plugin {
-
-            @SuppressWarnings("unused")
-            public OneParameterIncorrectType(Object object) {
-
-            }
-        }
-
-        final Collection<Class<? extends Plugin>> classes = Arrays.asList(
-            TooManyParametersPlugin.class,
-            TwoParametersFirstIncorrectType.class,
-            TwoParametersSecondIncorrectType.class,
-            OneParameterIncorrectType.class
-        );
-        for (Class<? extends Plugin> pluginClass : classes) {
-            final Path home = createTempDir();
-            final Settings settings = Settings.builder().put(Environment.PATH_HOME_SETTING.getKey(), home).build();
-            final IllegalStateException e = expectThrows(IllegalStateException.class, () -> newPluginsService(settings, pluginClass));
-            assertThat(e, hasToString(containsString("no public constructor of correct signature")));
-        }
-    }
-
-    public void testSortBundlesCycleSelfReference() throws Exception {
-        Path pluginDir = createTempDir();
-        PluginInfo info = new PluginInfo("foo", "desc", "1.0", Version.CURRENT, "1.8", "MyPlugin", Collections.singletonList("foo"), false);
-        PluginsService.Bundle bundle = new PluginsService.Bundle(info, pluginDir);
-        IllegalStateException e = expectThrows(
-            IllegalStateException.class,
-            () -> PluginsService.sortBundles(Collections.singleton(bundle))
-        );
-        assertEquals("Cycle found in plugin dependencies: foo -> foo", e.getMessage());
-    }
-
-    public void testSortBundlesCycle() throws Exception {
-        Path pluginDir = createTempDir();
-        Set<PluginsService.Bundle> bundles = new LinkedHashSet<>(); // control iteration order, so we get know the beginning of the cycle
-        PluginInfo info = new PluginInfo("foo", "desc", "1.0", Version.CURRENT, "1.8", "MyPlugin", Arrays.asList("bar", "other"), false);
-        bundles.add(new PluginsService.Bundle(info, pluginDir));
-        PluginInfo info2 = new PluginInfo(
-            "bar",
-            "desc",
-            "1.0",
-            Version.CURRENT,
-            "1.8",
-            "MyPlugin",
-            Collections.singletonList("baz"),
-            false
-        );
-        bundles.add(new PluginsService.Bundle(info2, pluginDir));
-        PluginInfo info3 = new PluginInfo(
-            "baz",
-            "desc",
-            "1.0",
-            Version.CURRENT,
-            "1.8",
-            "MyPlugin",
-            Collections.singletonList("foo"),
-            false
-        );
-        bundles.add(new PluginsService.Bundle(info3, pluginDir));
-        PluginInfo info4 = new PluginInfo("other", "desc", "1.0", Version.CURRENT, "1.8", "MyPlugin", Collections.emptyList(), false);
-        bundles.add(new PluginsService.Bundle(info4, pluginDir));
-
-        IllegalStateException e = expectThrows(IllegalStateException.class, () -> PluginsService.sortBundles(bundles));
-        assertEquals("Cycle found in plugin dependencies: foo -> bar -> baz -> foo", e.getMessage());
-    }
-
-    public void testSortBundlesSingle() throws Exception {
-        Path pluginDir = createTempDir();
-        PluginInfo info = new PluginInfo("foo", "desc", "1.0", Version.CURRENT, "1.8", "MyPlugin", Collections.emptyList(), false);
-        PluginsService.Bundle bundle = new PluginsService.Bundle(info, pluginDir);
-        List<PluginsService.Bundle> sortedBundles = PluginsService.sortBundles(Collections.singleton(bundle));
-        assertThat(sortedBundles, Matchers.contains(bundle));
-    }
-
-    public void testSortBundlesNoDeps() throws Exception {
-        Path pluginDir = createTempDir();
-        Set<PluginsService.Bundle> bundles = new LinkedHashSet<>(); // control iteration order
-        PluginInfo info1 = new PluginInfo("foo", "desc", "1.0", Version.CURRENT, "1.8", "MyPlugin", Collections.emptyList(), false);
-        PluginsService.Bundle bundle1 = new PluginsService.Bundle(info1, pluginDir);
-        bundles.add(bundle1);
-        PluginInfo info2 = new PluginInfo("bar", "desc", "1.0", Version.CURRENT, "1.8", "MyPlugin", Collections.emptyList(), false);
-        PluginsService.Bundle bundle2 = new PluginsService.Bundle(info2, pluginDir);
-        bundles.add(bundle2);
-        PluginInfo info3 = new PluginInfo("baz", "desc", "1.0", Version.CURRENT, "1.8", "MyPlugin", Collections.emptyList(), false);
-        PluginsService.Bundle bundle3 = new PluginsService.Bundle(info3, pluginDir);
-        bundles.add(bundle3);
-        List<PluginsService.Bundle> sortedBundles = PluginsService.sortBundles(bundles);
-        assertThat(sortedBundles, Matchers.contains(bundle1, bundle2, bundle3));
-    }
-
-    public void testSortBundlesMissingRequiredDep() throws Exception {
-        Path pluginDir = createTempDir();
-        PluginInfo info = new PluginInfo("foo", "desc", "1.0", Version.CURRENT, "1.8", "MyPlugin", Collections.singletonList("dne"), false);
-        PluginsService.Bundle bundle = new PluginsService.Bundle(info, pluginDir);
-        IllegalArgumentException e = expectThrows(
-            IllegalArgumentException.class,
-            () -> PluginsService.sortBundles(Collections.singleton(bundle))
-        );
-        assertEquals("Missing plugin [dne], dependency of [foo]", e.getMessage());
-    }
-
-    public void testSortBundlesMissingOptionalDep() throws Exception {
-        try (MockLogAppender mockLogAppender = MockLogAppender.createForLoggers(LogManager.getLogger(PluginsService.class))) {
-            mockLogAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
-                    "[.test] warning",
-                    "org.opensearch.plugins.PluginsService",
-                    Level.WARN,
-                    "Missing plugin [dne], dependency of [foo]"
-                )
-            );
-            Path pluginDir = createTempDir();
-            PluginInfo info = new PluginInfo(
-                "foo",
-                "desc",
-                "1.0",
-                Version.CURRENT,
-                "1.8",
-                "MyPlugin",
-                Collections.singletonList("dne;optional=true"),
-                false
-            );
-            PluginsService.Bundle bundle = new PluginsService.Bundle(info, pluginDir);
-            PluginsService.sortBundles(Collections.singleton(bundle));
-            mockLogAppender.assertAllExpectationsMatched();
-        }
-    }
-
-    public void testSortBundlesCommonDep() throws Exception {
-        Path pluginDir = createTempDir();
-        Set<PluginsService.Bundle> bundles = new LinkedHashSet<>(); // control iteration order
-        PluginInfo info1 = new PluginInfo("grandparent", "desc", "1.0", Version.CURRENT, "1.8", "MyPlugin", Collections.emptyList(), false);
-        PluginsService.Bundle bundle1 = new PluginsService.Bundle(info1, pluginDir);
-        bundles.add(bundle1);
-        PluginInfo info2 = new PluginInfo(
-            "foo",
-            "desc",
-            "1.0",
-            Version.CURRENT,
-            "1.8",
-            "MyPlugin",
-            Collections.singletonList("common"),
-            false
-        );
-        PluginsService.Bundle bundle2 = new PluginsService.Bundle(info2, pluginDir);
-        bundles.add(bundle2);
-        PluginInfo info3 = new PluginInfo(
-            "bar",
-            "desc",
-            "1.0",
-            Version.CURRENT,
-            "1.8",
-            "MyPlugin",
-            Collections.singletonList("common"),
-            false
-        );
-        PluginsService.Bundle bundle3 = new PluginsService.Bundle(info3, pluginDir);
-        bundles.add(bundle3);
-        PluginInfo info4 = new PluginInfo(
-            "common",
-            "desc",
-            "1.0",
-            Version.CURRENT,
-            "1.8",
-            "MyPlugin",
-            Collections.singletonList("grandparent"),
-            false
-        );
-        PluginsService.Bundle bundle4 = new PluginsService.Bundle(info4, pluginDir);
-        bundles.add(bundle4);
-        List<PluginsService.Bundle> sortedBundles = PluginsService.sortBundles(bundles);
-        assertThat(sortedBundles, Matchers.contains(bundle1, bundle4, bundle2, bundle3));
-    }
-
-    public void testSortBundlesAlreadyOrdered() throws Exception {
-        Path pluginDir = createTempDir();
-        Set<PluginsService.Bundle> bundles = new LinkedHashSet<>(); // control iteration order
-        PluginInfo info1 = new PluginInfo("dep", "desc", "1.0", Version.CURRENT, "1.8", "MyPlugin", Collections.emptyList(), false);
-        PluginsService.Bundle bundle1 = new PluginsService.Bundle(info1, pluginDir);
-        bundles.add(bundle1);
-        PluginInfo info2 = new PluginInfo(
-            "myplugin",
-            "desc",
-            "1.0",
-            Version.CURRENT,
-            "1.8",
-            "MyPlugin",
-            Collections.singletonList("dep"),
-            false
-        );
-        PluginsService.Bundle bundle2 = new PluginsService.Bundle(info2, pluginDir);
-        bundles.add(bundle2);
-        List<PluginsService.Bundle> sortedBundles = PluginsService.sortBundles(bundles);
-        assertThat(sortedBundles, Matchers.contains(bundle1, bundle2));
-    }
-
-    public static class DummyClass1 {}
-
-    public static class DummyClass2 {}
-
-    public static class DummyClass3 {}
-
-    void makeJar(Path jarFile, Class... classes) throws Exception {
-        try (ZipOutputStream out = new ZipOutputStream(Files.newOutputStream(jarFile))) {
-            for (Class clazz : classes) {
-                String relativePath = clazz.getCanonicalName().replaceAll("\\.", "/") + ".class";
-                if (relativePath.contains(PluginsServiceTests.class.getSimpleName())) {
-                    // static inner class of this test
-                    relativePath = relativePath.replace("/" + clazz.getSimpleName(), "$" + clazz.getSimpleName());
-                }
-
-                Path codebase = PathUtils.get(clazz.getProtectionDomain().getCodeSource().getLocation().toURI());
-                if (codebase.toString().endsWith(".jar")) {
-                    // copy from jar, exactly as is
-                    out.putNextEntry(new ZipEntry(relativePath));
-                    try (ZipInputStream in = new ZipInputStream(Files.newInputStream(codebase))) {
-                        ZipEntry entry = in.getNextEntry();
-                        while (entry != null) {
-                            if (entry.getName().equals(relativePath)) {
-                                byte[] buffer = new byte[10 * 1024];
-                                int read = in.read(buffer);
-                                while (read != -1) {
-                                    out.write(buffer, 0, read);
-                                    read = in.read(buffer);
-                                }
-                                break;
-                            }
-                            in.closeEntry();
-                            entry = in.getNextEntry();
-                        }
-                    }
-                } else {
-                    // copy from dir, and use a different canonical path to not conflict with test classpath
-                    out.putNextEntry(new ZipEntry("test/" + clazz.getSimpleName() + ".class"));
-                    Files.copy(codebase.resolve(relativePath), out);
-                }
-                out.closeEntry();
-            }
-        }
-    }
-
-    public void testJarHellDuplicateCodebaseWithDep() throws Exception {
-        Path pluginDir = createTempDir();
-        Path dupJar = pluginDir.resolve("dup.jar");
-        makeJar(dupJar);
-        Map<String, Set<URL>> transitiveDeps = new HashMap<>();
-        transitiveDeps.put("dep", Collections.singleton(dupJar.toUri().toURL()));
-        PluginInfo info1 = new PluginInfo(
-            "myplugin",
-            "desc",
-            "1.0",
-            Version.CURRENT,
-            "1.8",
-            "MyPlugin",
-            Collections.singletonList("dep"),
-            false
-        );
-        PluginsService.Bundle bundle = new PluginsService.Bundle(info1, pluginDir);
-        IllegalStateException e = expectThrows(
-            IllegalStateException.class,
-            () -> PluginsService.checkBundleJarHell(JarHell.parseClassPath(), bundle, transitiveDeps)
-        );
-        assertEquals("failed to load plugin myplugin due to jar hell", e.getMessage());
-        assertThat(e.getCause().getMessage(), containsString("jar hell! duplicate codebases with extended plugin"));
-    }
-
-    public void testJarHellDuplicateCodebaseAcrossDeps() throws Exception {
-        Path pluginDir = createTempDir();
-        Path pluginJar = pluginDir.resolve("plugin.jar");
-        makeJar(pluginJar, DummyClass1.class);
-        Path otherDir = createTempDir();
-        Path dupJar = otherDir.resolve("dup.jar");
-        makeJar(dupJar, DummyClass2.class);
-        Map<String, Set<URL>> transitiveDeps = new HashMap<>();
-        transitiveDeps.put("dep1", Collections.singleton(dupJar.toUri().toURL()));
-        transitiveDeps.put("dep2", Collections.singleton(dupJar.toUri().toURL()));
-        PluginInfo info1 = new PluginInfo(
-            "myplugin",
-            "desc",
-            "1.0",
-            Version.CURRENT,
-            "1.8",
-            "MyPlugin",
-            Arrays.asList("dep1", "dep2"),
-            false
-        );
-        PluginsService.Bundle bundle = new PluginsService.Bundle(info1, pluginDir);
-        IllegalStateException e = expectThrows(
-            IllegalStateException.class,
-            () -> PluginsService.checkBundleJarHell(JarHell.parseClassPath(), bundle, transitiveDeps)
-        );
-        assertEquals("failed to load plugin myplugin due to jar hell", e.getMessage());
-        assertThat(e.getCause().getMessage(), containsString("jar hell!"));
-        assertThat(e.getCause().getMessage(), containsString("duplicate codebases"));
-    }
-
-    // Note: testing dup codebase with core is difficult because it requires a symlink, but we have mock filesystems and security manager
-
-    public void testJarHellDuplicateClassWithCore() throws Exception {
-        // need a jar file of core dep, use log4j here
-        Path pluginDir = createTempDir();
-        Path pluginJar = pluginDir.resolve("plugin.jar");
-        makeJar(pluginJar, Level.class);
-        PluginInfo info1 = new PluginInfo("myplugin", "desc", "1.0", Version.CURRENT, "1.8", "MyPlugin", Collections.emptyList(), false);
-        PluginsService.Bundle bundle = new PluginsService.Bundle(info1, pluginDir);
-        IllegalStateException e = expectThrows(
-            IllegalStateException.class,
-            () -> PluginsService.checkBundleJarHell(JarHell.parseClassPath(), bundle, new HashMap<>())
-        );
-        assertEquals("failed to load plugin myplugin due to jar hell", e.getMessage());
-        assertThat(e.getCause().getMessage(), containsString("jar hell!"));
-        assertThat(e.getCause().getMessage(), containsString("Level"));
-    }
-
-    public void testJarHellDuplicateClassWithDep() throws Exception {
-        Path pluginDir = createTempDir();
-        Path pluginJar = pluginDir.resolve("plugin.jar");
-        makeJar(pluginJar, DummyClass1.class);
-        Path depDir = createTempDir();
-        Path depJar = depDir.resolve("dep.jar");
-        makeJar(depJar, DummyClass1.class);
-        Map<String, Set<URL>> transitiveDeps = new HashMap<>();
-        transitiveDeps.put("dep", Collections.singleton(depJar.toUri().toURL()));
-        PluginInfo info1 = new PluginInfo(
-            "myplugin",
-            "desc",
-            "1.0",
-            Version.CURRENT,
-            "1.8",
-            "MyPlugin",
-            Collections.singletonList("dep"),
-            false
-        );
-        PluginsService.Bundle bundle = new PluginsService.Bundle(info1, pluginDir);
-        IllegalStateException e = expectThrows(
-            IllegalStateException.class,
-            () -> PluginsService.checkBundleJarHell(JarHell.parseClassPath(), bundle, transitiveDeps)
-        );
-        assertEquals("failed to load plugin myplugin due to jar hell", e.getMessage());
-        assertThat(e.getCause().getMessage(), containsString("jar hell!"));
-        assertThat(e.getCause().getMessage(), containsString("DummyClass1"));
-    }
-
-    public void testJarHellDuplicateClassAcrossDeps() throws Exception {
-        Path pluginDir = createTempDir();
-        Path pluginJar = pluginDir.resolve("plugin.jar");
-        makeJar(pluginJar, DummyClass1.class);
-        Path dep1Dir = createTempDir();
-        Path dep1Jar = dep1Dir.resolve("dep1.jar");
-        makeJar(dep1Jar, DummyClass2.class);
-        Path dep2Dir = createTempDir();
-        Path dep2Jar = dep2Dir.resolve("dep2.jar");
-        makeJar(dep2Jar, DummyClass2.class);
-        Map<String, Set<URL>> transitiveDeps = new HashMap<>();
-        transitiveDeps.put("dep1", Collections.singleton(dep1Jar.toUri().toURL()));
-        transitiveDeps.put("dep2", Collections.singleton(dep2Jar.toUri().toURL()));
-        PluginInfo info1 = new PluginInfo(
-            "myplugin",
-            "desc",
-            "1.0",
-            Version.CURRENT,
-            "1.8",
-            "MyPlugin",
-            Arrays.asList("dep1", "dep2"),
-            false
-        );
-        PluginsService.Bundle bundle = new PluginsService.Bundle(info1, pluginDir);
-        IllegalStateException e = expectThrows(
-            IllegalStateException.class,
-            () -> PluginsService.checkBundleJarHell(JarHell.parseClassPath(), bundle, transitiveDeps)
-        );
-        assertEquals("failed to load plugin myplugin due to jar hell", e.getMessage());
-        assertThat(e.getCause().getMessage(), containsString("jar hell!"));
-        assertThat(e.getCause().getMessage(), containsString("DummyClass2"));
-    }
-
-    public void testJarHellTransitiveMap() throws Exception {
-        Path pluginDir = createTempDir();
-        Path pluginJar = pluginDir.resolve("plugin.jar");
-        makeJar(pluginJar, DummyClass1.class);
-        Path dep1Dir = createTempDir();
-        Path dep1Jar = dep1Dir.resolve("dep1.jar");
-        makeJar(dep1Jar, DummyClass2.class);
-        Path dep2Dir = createTempDir();
-        Path dep2Jar = dep2Dir.resolve("dep2.jar");
-        makeJar(dep2Jar, DummyClass3.class);
-        Map<String, Set<URL>> transitiveDeps = new HashMap<>();
-        transitiveDeps.put("dep1", Collections.singleton(dep1Jar.toUri().toURL()));
-        transitiveDeps.put("dep2", Collections.singleton(dep2Jar.toUri().toURL()));
-        PluginInfo info1 = new PluginInfo(
-            "myplugin",
-            "desc",
-            "1.0",
-            Version.CURRENT,
-            "1.8",
-            "MyPlugin",
-            Arrays.asList("dep1", "dep2"),
-            false
-        );
-        PluginsService.Bundle bundle = new PluginsService.Bundle(info1, pluginDir);
-        PluginsService.checkBundleJarHell(JarHell.parseClassPath(), bundle, transitiveDeps);
-        Set<URL> deps = transitiveDeps.get("myplugin");
-        assertNotNull(deps);
-        assertThat(deps, containsInAnyOrder(pluginJar.toUri().toURL(), dep1Jar.toUri().toURL(), dep2Jar.toUri().toURL()));
-    }
-
-    public void testNonExtensibleDep() throws Exception {
-        // This test opens a child classloader, reading a jar under the test temp
-        // dir (a dummy plugin). Classloaders are closed by GC, so when test teardown
-        // occurs the jar is deleted while the classloader is still open. However, on
-        // windows, files cannot be deleted when they are still open by a process.
-        assumeFalse("windows deletion behavior is asinine", Constants.WINDOWS);
-
-        Path homeDir = createTempDir();
-        Settings settings = Settings.builder().put(Environment.PATH_HOME_SETTING.getKey(), homeDir).build();
-        Path pluginsDir = homeDir.resolve("plugins");
-        Path mypluginDir = pluginsDir.resolve("myplugin");
-        PluginTestUtil.writePluginProperties(
-            mypluginDir,
-            "description",
-            "whatever",
-            "name",
-            "myplugin",
-            "version",
-            "1.0.0",
-            "opensearch.version",
-            Version.CURRENT.toString(),
-            "java.version",
-            System.getProperty("java.specification.version"),
-            "extended.plugins",
-            "nonextensible",
-            "classname",
-            "test.DummyPlugin"
-        );
-        try (InputStream jar = PluginsServiceTests.class.getResourceAsStream("dummy-plugin.jar")) {
-            Files.copy(jar, mypluginDir.resolve("plugin.jar"));
-        }
-        Path nonextensibleDir = pluginsDir.resolve("nonextensible");
-        PluginTestUtil.writePluginProperties(
-            nonextensibleDir,
-            "description",
-            "whatever",
-            "name",
-            "nonextensible",
-            "version",
-            "1.0.0",
-            "opensearch.version",
-            Version.CURRENT.toString(),
-            "java.version",
-            System.getProperty("java.specification.version"),
-            "classname",
-            "test.NonExtensiblePlugin"
-        );
-        try (InputStream jar = PluginsServiceTests.class.getResourceAsStream("non-extensible-plugin.jar")) {
-            Files.copy(jar, nonextensibleDir.resolve("plugin.jar"));
-        }
-        IllegalStateException e = expectThrows(IllegalStateException.class, () -> newPluginsService(settings));
-        assertEquals("Plugin [myplugin] cannot extend non-extensible plugin [nonextensible]", e.getMessage());
-    }
-
-    public void testIncompatibleOpenSearchVersion() throws Exception {
-        PluginInfo info = new PluginInfo(
-            "my_plugin",
-            "desc",
-            "1.0",
-            LegacyESVersion.fromId(6000099),
-            "1.8",
-            "FakePlugin",
-            Collections.emptyList(),
-            false
-        );
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginsService.verifyCompatibility(info));
-        assertThat(e.getMessage(), containsString("was built for OpenSearch version 6.0.0"));
-    }
-
-    public void testCompatibleOpenSearchVersionRange() {
-        List<SemverRange> pluginCompatibilityRange = List.of(new SemverRange(Version.CURRENT, SemverRange.RangeOperator.TILDE));
-        PluginInfo info = new PluginInfo(
-            "my_plugin",
-            "desc",
-            "1.0",
-            pluginCompatibilityRange,
-            "1.8",
-            "FakePlugin",
-            null,
-            Collections.emptyList(),
-            false
-        );
-        PluginsService.verifyCompatibility(info);
-    }
-
-    public void testIncompatibleOpenSearchVersionRange() {
-        // Version.CURRENT is behind by one with respect to patch version in the range
-        List<SemverRange> pluginCompatibilityRange = List.of(
-            new SemverRange(
-                VersionUtils.getVersion(Version.CURRENT.major, Version.CURRENT.minor, (byte) (Version.CURRENT.revision + 1)),
-                SemverRange.RangeOperator.TILDE
-            )
-        );
-        PluginInfo info = new PluginInfo(
-            "my_plugin",
-            "desc",
-            "1.0",
-            pluginCompatibilityRange,
-            "1.8",
-            "FakePlugin",
-            null,
-            Collections.emptyList(),
-            false
-        );
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginsService.verifyCompatibility(info));
-        assertThat(e.getMessage(), containsString("was built for OpenSearch version "));
-    }
-
-    public void testIncompatibleJavaVersion() throws Exception {
-        PluginInfo info = new PluginInfo(
-            "my_plugin",
-            "desc",
-            "1.0",
-            Version.CURRENT,
-            "1000000",
-            "FakePlugin",
-            Collections.emptyList(),
-            false
-        );
-        IllegalStateException e = expectThrows(IllegalStateException.class, () -> PluginsService.verifyCompatibility(info));
-        assertThat(e.getMessage(), containsString("my_plugin requires Java"));
-    }
-
-    public void testFindPluginDirs() throws Exception {
-        final Path plugins = createTempDir();
-
-        try (MockLogAppender mockLogAppender = MockLogAppender.createForLoggers(LogManager.getLogger(PluginsService.class))) {
-            mockLogAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
-                    "[.test] warning",
-                    "org.opensearch.plugins.PluginsService",
-                    Level.WARN,
-                    "Non-plugin file located in the plugins folder with the following name: [.DS_Store]"
-                )
-            );
-
-            final Path fake = plugins.resolve("fake");
-            Path testFile = plugins.resolve(".DS_Store");
-            Files.createFile(testFile);
-
-            PluginTestUtil.writePluginProperties(
-                fake,
-                "description",
-                "description",
-                "name",
-                "fake",
-                "version",
-                "1.0.0",
-                "opensearch.version",
-                Version.CURRENT.toString(),
-                "java.version",
-                System.getProperty("java.specification.version"),
-                "classname",
-                "test.DummyPlugin"
-            );
-
-            try (InputStream jar = PluginsServiceTests.class.getResourceAsStream("dummy-plugin.jar")) {
-                Files.copy(jar, fake.resolve("plugin.jar"));
-            }
-
-            assertThat(PluginsService.findPluginDirs(plugins), containsInAnyOrder(fake));
-            mockLogAppender.assertAllExpectationsMatched();
-        }
-    }
-
-    public void testExistingMandatoryClasspathPlugin() {
-        final Settings settings = Settings.builder()
-            .put("path.home", createTempDir())
-            .put("plugin.mandatory", "org.opensearch.plugins.PluginsServiceTests$FakePlugin")
-            .build();
-        newPluginsService(settings, FakePlugin.class);
-    }
-
-    public static class FakePlugin extends Plugin {
-
-        public FakePlugin() {
-
-        }
-
-    }
-
-    public void testExistingMandatoryInstalledPlugin() throws IOException {
-        // This test opens a child classloader, reading a jar under the test temp
-        // dir (a dummy plugin). Classloaders are closed by GC, so when test teardown
-        // occurs the jar is deleted while the classloader is still open. However, on
-        // windows, files cannot be deleted when they are still open by a process.
-        assumeFalse("windows deletion behavior is asinine", Constants.WINDOWS);
-        final Path pathHome = createTempDir();
-        final Path plugins = pathHome.resolve("plugins");
-        final Path fake = plugins.resolve("fake");
-
-        PluginTestUtil.writePluginProperties(
-            fake,
-            "description",
-            "description",
-            "name",
-            "fake",
-            "version",
-            "1.0.0",
-            "opensearch.version",
-            Version.CURRENT.toString(),
-            "java.version",
-            System.getProperty("java.specification.version"),
-            "classname",
-            "test.DummyPlugin"
-        );
-        try (InputStream jar = PluginsServiceTests.class.getResourceAsStream("dummy-plugin.jar")) {
-            Files.copy(jar, fake.resolve("plugin.jar"));
-        }
-
-        final Settings settings = Settings.builder().put("path.home", pathHome).put("plugin.mandatory", "fake").build();
-        newPluginsService(settings);
-    }
-
-    public void testPluginFromParentClassLoader() throws IOException {
-        final Path pathHome = createTempDir();
-        final Path plugins = pathHome.resolve("plugins");
-        final Path fake = plugins.resolve("fake");
-
-        PluginTestUtil.writePluginProperties(
-            fake,
-            "description",
-            "description",
-            "name",
-            "fake",
-            "version",
-            "1.0.0",
-            "opensearch.version",
-            Version.CURRENT.toString(),
-            "java.version",
-            System.getProperty("java.specification.version"),
-            "classname",
-            TestPlugin.class.getName()
-        ); // set a class defined outside the bundle (in parent class-loader of plugin)
-
-        final Settings settings = Settings.builder().put("path.home", pathHome).put("plugin.mandatory", "fake").build();
-        IllegalStateException exception = expectThrows(IllegalStateException.class, () -> newPluginsService(settings));
-        assertThat(
-            exception,
-            hasToString(
-                containsString(
-                    "Plugin [fake] must reference a class loader local Plugin class ["
-                        + TestPlugin.class.getName()
-                        + "] (class loader ["
-                        + PluginsServiceTests.class.getClassLoader()
-                        + "])"
-                )
-            )
-        );
-    }
-
-    public void testPluginLoadFailure() throws IOException {
-        final Path pathHome = createTempDir();
-        final Path plugins = pathHome.resolve("plugins");
-        final Path fake = plugins.resolve("fake");
-
-        PluginTestUtil.writePluginProperties(
-            fake,
-            "description",
-            "description",
-            "name",
-            "fake",
-            "version",
-            "1.0.0",
-            "opensearch.version",
-            Version.CURRENT.toString(),
-            "java.version",
-            System.getProperty("java.specification.version"),
-            "classname",
-            "DummyClass"
-        ); // This class is not present in Path, hence plugin loading will throw ClassNotFoundException
-
-        final Settings settings = Settings.builder().put("path.home", pathHome).put("plugin.mandatory", "fake").build();
-        RuntimeException exception = expectThrows(RuntimeException.class, () -> newPluginsService(settings));
-        assertTrue(exception.getCause() instanceof ClassNotFoundException);
-        assertThat(exception, hasToString(containsString("Unable to load plugin class [DummyClass]")));
-    }
-
-    public void testExtensiblePlugin() {
-        TestExtensiblePlugin extensiblePlugin = new TestExtensiblePlugin();
-        PluginsService.loadExtensions(
-            Collections.singletonList(
-                Tuple.tuple(
-                    new PluginInfo("extensible", null, null, Version.CURRENT, null, null, Collections.emptyList(), false),
-                    extensiblePlugin
-                )
-            )
-        );
-
-        assertThat(extensiblePlugin.extensions, notNullValue());
-        assertThat(extensiblePlugin.extensions, hasSize(0));
-
-        extensiblePlugin = new TestExtensiblePlugin();
-        TestPlugin testPlugin = new TestPlugin();
-        PluginsService.loadExtensions(
-            Arrays.asList(
-                Tuple.tuple(
-                    new PluginInfo("extensible", null, null, Version.CURRENT, null, null, Collections.emptyList(), false),
-                    extensiblePlugin
-                ),
-                Tuple.tuple(
-                    new PluginInfo("test", null, null, Version.CURRENT, null, null, Collections.singletonList("extensible"), false),
-                    testPlugin
-                )
-            )
-        );
-
-        assertThat(extensiblePlugin.extensions, notNullValue());
-        assertThat(extensiblePlugin.extensions, hasSize(2));
-        assertThat(extensiblePlugin.extensions.get(0), instanceOf(TestExtension1.class));
-        assertThat(extensiblePlugin.extensions.get(1), instanceOf(TestExtension2.class));
-        assertThat(((TestExtension2) extensiblePlugin.extensions.get(1)).plugin, sameInstance(testPlugin));
-    }
-
-    public void testNoExtensionConstructors() {
-        TestPlugin plugin = new TestPlugin();
-        class TestExtension implements TestExtensionPoint {
-            private TestExtension() {}
-        }
-        IllegalStateException e = expectThrows(IllegalStateException.class, () -> {
-            PluginsService.createExtension(TestExtension.class, TestExtensionPoint.class, plugin);
-        });
-
-        assertThat(
-            e,
-            hasToString(
-                containsString(
-                    "no public constructor for extension ["
-                        + TestExtension.class.getName()
-                        + "] of type ["
-                        + TestExtensionPoint.class.getName()
-                        + "]"
-                )
-            )
-        );
-    }
-
-    public void testMultipleExtensionConstructors() {
-        TestPlugin plugin = new TestPlugin();
-        class TestExtension implements TestExtensionPoint {
-            public TestExtension() {}
-
-            public TestExtension(TestPlugin plugin) {
-
-            }
-        }
-        IllegalStateException e = expectThrows(IllegalStateException.class, () -> {
-            PluginsService.createExtension(TestExtension.class, TestExtensionPoint.class, plugin);
-        });
-
-        assertThat(
-            e,
-            hasToString(
-                containsString(
-                    "no unique public constructor for extension ["
-                        + TestExtension.class.getName()
-                        + "] of type ["
-                        + TestExtensionPoint.class.getName()
-                        + "]"
-                )
-            )
-        );
-    }
-
-    public void testBadSingleParameterConstructor() {
-        TestPlugin plugin = new TestPlugin();
-        IllegalStateException e = expectThrows(IllegalStateException.class, () -> {
-            PluginsService.createExtension(BadSingleParameterConstructorExtension.class, TestExtensionPoint.class, plugin);
-        });
-
-        assertThat(
-            e,
-            hasToString(
-                containsString(
-                    "signature of constructor for extension ["
-                        + BadSingleParameterConstructorExtension.class.getName()
-                        + "] of type ["
-                        + TestExtensionPoint.class.getName()
-                        + "] must be either () or ("
-                        + TestPlugin.class.getName()
-                        + "), not ("
-                        + String.class.getName()
-                        + ")"
-                )
-            )
-        );
-    }
-
-    public void testTooManyParametersExtensionConstructors() {
-        TestPlugin plugin = new TestPlugin();
-        IllegalStateException e = expectThrows(IllegalStateException.class, () -> {
-            PluginsService.createExtension(TooManyParametersConstructorExtension.class, TestExtensionPoint.class, plugin);
-        });
-
-        assertThat(
-            e,
-            hasToString(
-                containsString(
-                    "signature of constructor for extension ["
-                        + TooManyParametersConstructorExtension.class.getName()
-                        + "] of type ["
-                        + TestExtensionPoint.class.getName()
-                        + "] must be either () or ("
-                        + TestPlugin.class.getName()
-                        + ")"
-                )
-            )
-        );
-    }
-
-    public void testThrowingConstructor() {
-        TestPlugin plugin = new TestPlugin();
-        IllegalStateException e = expectThrows(IllegalStateException.class, () -> {
-            PluginsService.createExtension(ThrowingConstructorExtension.class, TestExtensionPoint.class, plugin);
-        });
-
-        assertThat(
-            e,
-            hasToString(
-                containsString(
-                    "failed to create extension ["
-                        + ThrowingConstructorExtension.class.getName()
-                        + "] of type ["
-                        + TestExtensionPoint.class.getName()
-                        + "]"
-                )
-            )
-        );
-        assertThat(e.getCause(), instanceOf(InvocationTargetException.class));
-        assertThat(e.getCause().getCause(), instanceOf(IllegalArgumentException.class));
-        assertThat(e.getCause().getCause(), hasToString(containsString("test constructor failure")));
-    }
-
-    public void testPluginCompatibilityWithSemverRange() {
-        // Compatible plugin and core versions
-        assertTrue(PluginsService.isPluginVersionCompatible(getPluginInfoWithWithSemverRange("1.0.0"), Version.fromString("1.0.0")));
-
-        assertTrue(PluginsService.isPluginVersionCompatible(getPluginInfoWithWithSemverRange("=1.0.0"), Version.fromString("1.0.0")));
-
-        assertTrue(PluginsService.isPluginVersionCompatible(getPluginInfoWithWithSemverRange("~1.0.0"), Version.fromString("1.0.0")));
-
-        assertTrue(PluginsService.isPluginVersionCompatible(getPluginInfoWithWithSemverRange("~1.0.1"), Version.fromString("1.0.2")));
-
-        // Incompatible plugin and core versions
-        assertFalse(PluginsService.isPluginVersionCompatible(getPluginInfoWithWithSemverRange("1.0.0"), Version.fromString("1.0.1")));
-
-        assertFalse(PluginsService.isPluginVersionCompatible(getPluginInfoWithWithSemverRange("=1.0.0"), Version.fromString("1.0.1")));
-
-        assertFalse(PluginsService.isPluginVersionCompatible(getPluginInfoWithWithSemverRange("~1.0.1"), Version.fromString("1.0.0")));
-
-        assertFalse(PluginsService.isPluginVersionCompatible(getPluginInfoWithWithSemverRange("~1.0.0"), Version.fromString("1.1.0")));
-    }
-
-    private PluginInfo getPluginInfoWithWithSemverRange(String semverRange) {
-        return new PluginInfo(
-            "my_plugin",
-            "desc",
-            "1.0",
-            List.of(SemverRange.fromString(semverRange)),
-            "1.8",
-            "FakePlugin",
-            null,
-            Collections.emptyList(),
-            false
-        );
-    }
+      public void testAdditionalSettings() {
+          Settings settings = Settings.builder()
+              .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir())
+              .put("my.setting", "test")
+              .put(IndexModule.INDEX_STORE_TYPE_SETTING.getKey(), IndexModule.Type.NIOFS.getSettingsKey())
+              .build();
+          PluginsService service = newPluginsService(settings, AdditionalSettingsPlugin1.class);
+          Settings newSettings = service.updatedSettings();
+          assertEquals("test", newSettings.get("my.setting")); // previous settings still exist
+          assertEquals("1", newSettings.get("foo.bar")); // added setting exists
+          // does not override pre existing settings
+          assertEquals(IndexModule.Type.NIOFS.getSettingsKey(), newSettings.get(IndexModule.INDEX_STORE_TYPE_SETTING.getKey()));
+      }
+
+     public void testAdditionalSettingsClash() {
+         Settings settings = Settings.builder().put(Environment.PATH_HOME_SETTING.getKey(), createTempDir()).build();
+         PluginsService service = newPluginsService(settings, AdditionalSettingsPlugin1.class, AdditionalSettingsPlugin2.class);
+         try {
+             service.updatedSettings();
+             fail("Expected exception when building updated settings");
+         } catch (IllegalArgumentException e) {
+             String msg = e.getMessage();
+             assertTrue(msg, msg.contains("Cannot have additional setting [foo.bar]"));
+             assertTrue(msg, msg.contains("plugin [" + AdditionalSettingsPlugin1.class.getName()));
+             assertTrue(msg, msg.contains("plugin [" + AdditionalSettingsPlugin2.class.getName()));
+         }
+     }
+
+     public void testExistingPluginMissingDescriptor() throws Exception {
+         Path pluginsDir = createTempDir();
+         Files.createDirectory(pluginsDir.resolve("plugin-missing-descriptor"));
+         IllegalStateException e = expectThrows(IllegalStateException.class, () -> PluginsService.getPluginBundles(pluginsDir));
+         assertThat(e.getMessage(), containsString("Could not load plugin descriptor for plugin directory [plugin-missing-descriptor]"));
+     }
+
+     public void testFilterPlugins() {
+         Settings settings = Settings.builder()
+             .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir())
+             .put("my.setting", "test")
+             .put(IndexModule.INDEX_STORE_TYPE_SETTING.getKey(), IndexModule.Type.NIOFS.getSettingsKey())
+             .build();
+         PluginsService service = newPluginsService(settings, AdditionalSettingsPlugin1.class, FilterablePlugin.class);
+         List<ScriptPlugin> scriptPlugins = service.filterPlugins(ScriptPlugin.class);
+         assertEquals(1, scriptPlugins.size());
+         assertEquals(FilterablePlugin.class, scriptPlugins.get(0).getClass());
+     }
+
+     public void testHiddenDirectories() throws IOException {
+         final Path home = createTempDir();
+         final Settings settings = Settings.builder().put(Environment.PATH_HOME_SETTING.getKey(), home).build();
+         final Path hidden = home.resolve("plugins").resolve(".hidden");
+         Files.createDirectories(hidden);
+         @SuppressWarnings("unchecked")
+         final IllegalStateException e = expectThrows(IllegalStateException.class, () -> newPluginsService(settings));
+         final String expected = "Could not load plugin descriptor for plugin directory [.hidden]";
+         assertThat(e, hasToString(containsString(expected)));
+     }
+
+     public void testStartupWithRemovingMarker() throws IOException {
+         final Path home = createTempDir();
+         final Settings settings = Settings.builder().put(Environment.PATH_HOME_SETTING.getKey(), home).build();
+         final Path fake = home.resolve("plugins").resolve("fake");
+         Files.createDirectories(fake);
+         Files.createFile(fake.resolve("plugin.jar"));
+         final Path removing = home.resolve("plugins").resolve(".removing-fake");
+         Files.createFile(removing);
+         PluginTestUtil.writePluginProperties(
+             fake,
+             "description",
+             "fake",
+             "name",
+             "fake",
+             "version",
+             "1.0.0",
+             "opensearch.version",
+             Version.CURRENT.toString(),
+             "java.version",
+             System.getProperty("java.specification.version"),
+             "classname",
+             "Fake",
+             "has.native.controller",
+             "false"
+         );
+         final IllegalStateException e = expectThrows(IllegalStateException.class, () -> newPluginsService(settings));
+         final String expected = String.format(
+             Locale.ROOT,
+             "found file [%s] from a failed attempt to remove the plugin [fake]; execute [opensearch-plugin remove fake]",
+             removing
+         );
+         assertThat(e, hasToString(containsString(expected)));
+     }
+
+     public void testLoadPluginWithNoPublicConstructor() {
+         class NoPublicConstructorPlugin extends Plugin {
+
+             private NoPublicConstructorPlugin() {
+
+             }
+
+         }
+
+         final Path home = createTempDir();
+         final Settings settings = Settings.builder().put(Environment.PATH_HOME_SETTING.getKey(), home).build();
+         final IllegalStateException e = expectThrows(
+             IllegalStateException.class,
+             () -> newPluginsService(settings, NoPublicConstructorPlugin.class)
+         );
+         assertThat(e, hasToString(containsString("no public constructor")));
+     }
+
+     public void testLoadPluginWithMultiplePublicConstructors() {
+         class MultiplePublicConstructorsPlugin extends Plugin {
+
+             @SuppressWarnings("unused")
+             public MultiplePublicConstructorsPlugin() {
+
+             }
+
+             @SuppressWarnings("unused")
+             public MultiplePublicConstructorsPlugin(final Settings settings) {
+
+             }
+
+         }
+
+         final Path home = createTempDir();
+         final Settings settings = Settings.builder().put(Environment.PATH_HOME_SETTING.getKey(), home).build();
+         final IllegalStateException e = expectThrows(
+             IllegalStateException.class,
+             () -> newPluginsService(settings, MultiplePublicConstructorsPlugin.class)
+         );
+         assertThat(e, hasToString(containsString("no unique public constructor")));
+     }
+
+     public void testLoadPluginWithNoPublicConstructorOfCorrectSignature() {
+         class TooManyParametersPlugin extends Plugin {
+
+             @SuppressWarnings("unused")
+             public TooManyParametersPlugin(Settings settings, Path configPath, Object object) {
+
+             }
+
+         }
+
+         class TwoParametersFirstIncorrectType extends Plugin {
+
+             @SuppressWarnings("unused")
+             public TwoParametersFirstIncorrectType(Object object, Path configPath) {
+
+             }
+         }
+
+         class TwoParametersSecondIncorrectType extends Plugin {
+
+             @SuppressWarnings("unused")
+             public TwoParametersSecondIncorrectType(Settings settings, Object object) {
+
+             }
+
+         }
+
+         class OneParameterIncorrectType extends Plugin {
+
+             @SuppressWarnings("unused")
+             public OneParameterIncorrectType(Object object) {
+
+             }
+         }
+
+         final Collection<Class<? extends Plugin>> classes = Arrays.asList(
+             TooManyParametersPlugin.class,
+             TwoParametersFirstIncorrectType.class,
+             TwoParametersSecondIncorrectType.class,
+             OneParameterIncorrectType.class
+         );
+         for (Class<? extends Plugin> pluginClass : classes) {
+             final Path home = createTempDir();
+             final Settings settings = Settings.builder().put(Environment.PATH_HOME_SETTING.getKey(), home).build();
+             final IllegalStateException e = expectThrows(IllegalStateException.class, () -> newPluginsService(settings, pluginClass));
+             assertThat(e, hasToString(containsString("no public constructor of correct signature")));
+         }
+     }
+
+     public void testSortBundlesCycleSelfReference() throws Exception {
+         Path pluginDir = createTempDir();
+         PluginInfo info = new PluginInfo("foo", "desc", "1.0", Version.CURRENT, "1.8", "MyPlugin", Collections.singletonList("foo"), false);
+         PluginsService.Bundle bundle = new PluginsService.Bundle(info, pluginDir);
+         IllegalStateException e = expectThrows(
+             IllegalStateException.class,
+             () -> PluginsService.sortBundles(Collections.singleton(bundle))
+         );
+         assertEquals("Cycle found in plugin dependencies: foo -> foo", e.getMessage());
+     }
+
+     public void testSortBundlesCycle() throws Exception {
+         Path pluginDir = createTempDir();
+         Set<PluginsService.Bundle> bundles = new LinkedHashSet<>(); // control iteration order, so we get know the beginning of the cycle
+         PluginInfo info = new PluginInfo("foo", "desc", "1.0", Version.CURRENT, "1.8", "MyPlugin", Arrays.asList("bar", "other"), false);
+         bundles.add(new PluginsService.Bundle(info, pluginDir));
+         PluginInfo info2 = new PluginInfo(
+             "bar",
+             "desc",
+             "1.0",
+             Version.CURRENT,
+             "1.8",
+             "MyPlugin",
+             Collections.singletonList("baz"),
+             false
+         );
+         bundles.add(new PluginsService.Bundle(info2, pluginDir));
+         PluginInfo info3 = new PluginInfo(
+             "baz",
+             "desc",
+             "1.0",
+             Version.CURRENT,
+             "1.8",
+             "MyPlugin",
+             Collections.singletonList("foo"),
+             false
+         );
+         bundles.add(new PluginsService.Bundle(info3, pluginDir));
+         PluginInfo info4 = new PluginInfo("other", "desc", "1.0", Version.CURRENT, "1.8", "MyPlugin", Collections.emptyList(), false);
+         bundles.add(new PluginsService.Bundle(info4, pluginDir));
+
+         IllegalStateException e = expectThrows(IllegalStateException.class, () -> PluginsService.sortBundles(bundles));
+         assertEquals("Cycle found in plugin dependencies: foo -> bar -> baz -> foo", e.getMessage());
+     }
+
+     public void testSortBundlesSingle() throws Exception {
+         Path pluginDir = createTempDir();
+         PluginInfo info = new PluginInfo("foo", "desc", "1.0", Version.CURRENT, "1.8", "MyPlugin", Collections.emptyList(), false);
+         PluginsService.Bundle bundle = new PluginsService.Bundle(info, pluginDir);
+         List<PluginsService.Bundle> sortedBundles = PluginsService.sortBundles(Collections.singleton(bundle));
+         assertThat(sortedBundles, Matchers.contains(bundle));
+     }
+
+     public void testSortBundlesNoDeps() throws Exception {
+         Path pluginDir = createTempDir();
+         Set<PluginsService.Bundle> bundles = new LinkedHashSet<>(); // control iteration order
+         PluginInfo info1 = new PluginInfo("foo", "desc", "1.0", Version.CURRENT, "1.8", "MyPlugin", Collections.emptyList(), false);
+         PluginsService.Bundle bundle1 = new PluginsService.Bundle(info1, pluginDir);
+         bundles.add(bundle1);
+         PluginInfo info2 = new PluginInfo("bar", "desc", "1.0", Version.CURRENT, "1.8", "MyPlugin", Collections.emptyList(), false);
+         PluginsService.Bundle bundle2 = new PluginsService.Bundle(info2, pluginDir);
+         bundles.add(bundle2);
+         PluginInfo info3 = new PluginInfo("baz", "desc", "1.0", Version.CURRENT, "1.8", "MyPlugin", Collections.emptyList(), false);
+         PluginsService.Bundle bundle3 = new PluginsService.Bundle(info3, pluginDir);
+         bundles.add(bundle3);
+         List<PluginsService.Bundle> sortedBundles = PluginsService.sortBundles(bundles);
+         assertThat(sortedBundles, Matchers.contains(bundle1, bundle2, bundle3));
+     }
+
+     public void testSortBundlesMissingRequiredDep() throws Exception {
+         Path pluginDir = createTempDir();
+         PluginInfo info = new PluginInfo("foo", "desc", "1.0", Version.CURRENT, "1.8", "MyPlugin", Collections.singletonList("dne"), false);
+         PluginsService.Bundle bundle = new PluginsService.Bundle(info, pluginDir);
+         IllegalArgumentException e = expectThrows(
+             IllegalArgumentException.class,
+             () -> PluginsService.sortBundles(Collections.singleton(bundle))
+         );
+         assertEquals("Missing plugin [dne], dependency of [foo]", e.getMessage());
+     }
+
+     public void testSortBundlesMissingOptionalDep() throws Exception {
+         try (MockLogAppender mockLogAppender = MockLogAppender.createForLoggers(LogManager.getLogger(PluginsService.class))) {
+             mockLogAppender.addExpectation(
+                 new MockLogAppender.SeenEventExpectation(
+                     "[.test] warning",
+                     "org.opensearch.plugins.PluginsService",
+                     Level.WARN,
+                     "Missing plugin [dne], dependency of [foo]"
+                 )
+             );
+             Path pluginDir = createTempDir();
+             PluginInfo info = new PluginInfo(
+                 "foo",
+                 "desc",
+                 "1.0",
+                 Version.CURRENT,
+                 "1.8",
+                 "MyPlugin",
+                 Collections.singletonList("dne;optional=true"),
+                 false
+             );
+             PluginsService.Bundle bundle = new PluginsService.Bundle(info, pluginDir);
+             PluginsService.sortBundles(Collections.singleton(bundle));
+             mockLogAppender.assertAllExpectationsMatched();
+         }
+     }
+
+     public void testSortBundlesCommonDep() throws Exception {
+         Path pluginDir = createTempDir();
+         Set<PluginsService.Bundle> bundles = new LinkedHashSet<>(); // control iteration order
+         PluginInfo info1 = new PluginInfo("grandparent", "desc", "1.0", Version.CURRENT, "1.8", "MyPlugin", Collections.emptyList(), false);
+         PluginsService.Bundle bundle1 = new PluginsService.Bundle(info1, pluginDir);
+         bundles.add(bundle1);
+         PluginInfo info2 = new PluginInfo(
+             "foo",
+             "desc",
+             "1.0",
+             Version.CURRENT,
+             "1.8",
+             "MyPlugin",
+             Collections.singletonList("common"),
+             false
+         );
+         PluginsService.Bundle bundle2 = new PluginsService.Bundle(info2, pluginDir);
+         bundles.add(bundle2);
+         PluginInfo info3 = new PluginInfo(
+             "bar",
+             "desc",
+             "1.0",
+             Version.CURRENT,
+             "1.8",
+             "MyPlugin",
+             Collections.singletonList("common"),
+             false
+         );
+         PluginsService.Bundle bundle3 = new PluginsService.Bundle(info3, pluginDir);
+         bundles.add(bundle3);
+         PluginInfo info4 = new PluginInfo(
+             "common",
+             "desc",
+             "1.0",
+             Version.CURRENT,
+             "1.8",
+             "MyPlugin",
+             Collections.singletonList("grandparent"),
+             false
+         );
+         PluginsService.Bundle bundle4 = new PluginsService.Bundle(info4, pluginDir);
+         bundles.add(bundle4);
+         List<PluginsService.Bundle> sortedBundles = PluginsService.sortBundles(bundles);
+         assertThat(sortedBundles, Matchers.contains(bundle1, bundle4, bundle2, bundle3));
+     }
+
+     public void testSortBundlesAlreadyOrdered() throws Exception {
+         Path pluginDir = createTempDir();
+         Set<PluginsService.Bundle> bundles = new LinkedHashSet<>(); // control iteration order
+         PluginInfo info1 = new PluginInfo("dep", "desc", "1.0", Version.CURRENT, "1.8", "MyPlugin", Collections.emptyList(), false);
+         PluginsService.Bundle bundle1 = new PluginsService.Bundle(info1, pluginDir);
+         bundles.add(bundle1);
+         PluginInfo info2 = new PluginInfo(
+             "myplugin",
+             "desc",
+             "1.0",
+             Version.CURRENT,
+             "1.8",
+             "MyPlugin",
+             Collections.singletonList("dep"),
+             false
+         );
+         PluginsService.Bundle bundle2 = new PluginsService.Bundle(info2, pluginDir);
+         bundles.add(bundle2);
+         List<PluginsService.Bundle> sortedBundles = PluginsService.sortBundles(bundles);
+         assertThat(sortedBundles, Matchers.contains(bundle1, bundle2));
+     }
+
+     public static class DummyClass1 {}
+
+     public static class DummyClass2 {}
+
+     public static class DummyClass3 {}
+
+     void makeJar(Path jarFile, Class... classes) throws Exception {
+         try (ZipOutputStream out = new ZipOutputStream(Files.newOutputStream(jarFile))) {
+             for (Class clazz : classes) {
+                 String relativePath = clazz.getCanonicalName().replaceAll("\\.", "/") + ".class";
+                 if (relativePath.contains(PluginsServiceTests.class.getSimpleName())) {
+                     // static inner class of this test
+                     relativePath = relativePath.replace("/" + clazz.getSimpleName(), "$" + clazz.getSimpleName());
+                 }
+
+                 Path codebase = PathUtils.get(clazz.getProtectionDomain().getCodeSource().getLocation().toURI());
+                 if (codebase.toString().endsWith(".jar")) {
+                     // copy from jar, exactly as is
+                     out.putNextEntry(new ZipEntry(relativePath));
+                     try (ZipInputStream in = new ZipInputStream(Files.newInputStream(codebase))) {
+                         ZipEntry entry = in.getNextEntry();
+                         while (entry != null) {
+                             if (entry.getName().equals(relativePath)) {
+                                 byte[] buffer = new byte[10 * 1024];
+                                 int read = in.read(buffer);
+                                 while (read != -1) {
+                                     out.write(buffer, 0, read);
+                                     read = in.read(buffer);
+                                 }
+                                 break;
+                             }
+                             in.closeEntry();
+                             entry = in.getNextEntry();
+                         }
+                     }
+                 } else {
+                     // copy from dir, and use a different canonical path to not conflict with test classpath
+                     out.putNextEntry(new ZipEntry("test/" + clazz.getSimpleName() + ".class"));
+                     Files.copy(codebase.resolve(relativePath), out);
+                 }
+                 out.closeEntry();
+             }
+         }
+     }
+
+     public void testJarHellDuplicateCodebaseWithDep() throws Exception {
+         Path pluginDir = createTempDir();
+         Path dupJar = pluginDir.resolve("dup.jar");
+         makeJar(dupJar);
+         Map<String, Set<URL>> transitiveDeps = new HashMap<>();
+         transitiveDeps.put("dep", Collections.singleton(dupJar.toUri().toURL()));
+         PluginInfo info1 = new PluginInfo(
+             "myplugin",
+             "desc",
+             "1.0",
+             Version.CURRENT,
+             "1.8",
+             "MyPlugin",
+             Collections.singletonList("dep"),
+             false
+         );
+         PluginsService.Bundle bundle = new PluginsService.Bundle(info1, pluginDir);
+         IllegalStateException e = expectThrows(
+             IllegalStateException.class,
+             () -> PluginsService.checkBundleJarHell(JarHell.parseClassPath(), bundle, transitiveDeps)
+         );
+         assertEquals("failed to load plugin myplugin due to jar hell", e.getMessage());
+         assertThat(e.getCause().getMessage(), containsString("jar hell! duplicate codebases with extended plugin"));
+     }
+
+     public void testJarHellDuplicateCodebaseAcrossDeps() throws Exception {
+         Path pluginDir = createTempDir();
+         Path pluginJar = pluginDir.resolve("plugin.jar");
+         makeJar(pluginJar, DummyClass1.class);
+         Path otherDir = createTempDir();
+         Path dupJar = otherDir.resolve("dup.jar");
+         makeJar(dupJar, DummyClass2.class);
+         Map<String, Set<URL>> transitiveDeps = new HashMap<>();
+         transitiveDeps.put("dep1", Collections.singleton(dupJar.toUri().toURL()));
+         transitiveDeps.put("dep2", Collections.singleton(dupJar.toUri().toURL()));
+         PluginInfo info1 = new PluginInfo(
+             "myplugin",
+             "desc",
+             "1.0",
+             Version.CURRENT,
+             "1.8",
+             "MyPlugin",
+             Arrays.asList("dep1", "dep2"),
+             false
+         );
+         PluginsService.Bundle bundle = new PluginsService.Bundle(info1, pluginDir);
+         IllegalStateException e = expectThrows(
+             IllegalStateException.class,
+             () -> PluginsService.checkBundleJarHell(JarHell.parseClassPath(), bundle, transitiveDeps)
+         );
+         assertEquals("failed to load plugin myplugin due to jar hell", e.getMessage());
+         assertThat(e.getCause().getMessage(), containsString("jar hell!"));
+         assertThat(e.getCause().getMessage(), containsString("duplicate codebases"));
+     }
+
+     // Note: testing dup codebase with core is difficult because it requires a symlink, but we have mock filesystems and security manager
+
+     public void testJarHellDuplicateClassWithCore() throws Exception {
+         // need a jar file of core dep, use log4j here
+         Path pluginDir = createTempDir();
+         Path pluginJar = pluginDir.resolve("plugin.jar");
+         makeJar(pluginJar, Level.class);
+         PluginInfo info1 = new PluginInfo("myplugin", "desc", "1.0", Version.CURRENT, "1.8", "MyPlugin", Collections.emptyList(), false);
+         PluginsService.Bundle bundle = new PluginsService.Bundle(info1, pluginDir);
+         IllegalStateException e = expectThrows(
+             IllegalStateException.class,
+             () -> PluginsService.checkBundleJarHell(JarHell.parseClassPath(), bundle, new HashMap<>())
+         );
+         assertEquals("failed to load plugin myplugin due to jar hell", e.getMessage());
+         assertThat(e.getCause().getMessage(), containsString("jar hell!"));
+         assertThat(e.getCause().getMessage(), containsString("Level"));
+     }
+
+     public void testJarHellDuplicateClassWithDep() throws Exception {
+         Path pluginDir = createTempDir();
+         Path pluginJar = pluginDir.resolve("plugin.jar");
+         makeJar(pluginJar, DummyClass1.class);
+         Path depDir = createTempDir();
+         Path depJar = depDir.resolve("dep.jar");
+         makeJar(depJar, DummyClass1.class);
+         Map<String, Set<URL>> transitiveDeps = new HashMap<>();
+         transitiveDeps.put("dep", Collections.singleton(depJar.toUri().toURL()));
+         PluginInfo info1 = new PluginInfo(
+             "myplugin",
+             "desc",
+             "1.0",
+             Version.CURRENT,
+             "1.8",
+             "MyPlugin",
+             Collections.singletonList("dep"),
+             false
+         );
+         PluginsService.Bundle bundle = new PluginsService.Bundle(info1, pluginDir);
+         IllegalStateException e = expectThrows(
+             IllegalStateException.class,
+             () -> PluginsService.checkBundleJarHell(JarHell.parseClassPath(), bundle, transitiveDeps)
+         );
+         assertEquals("failed to load plugin myplugin due to jar hell", e.getMessage());
+         assertThat(e.getCause().getMessage(), containsString("jar hell!"));
+         assertThat(e.getCause().getMessage(), containsString("DummyClass1"));
+     }
+
+     public void testJarHellDuplicateClassAcrossDeps() throws Exception {
+         Path pluginDir = createTempDir();
+         Path pluginJar = pluginDir.resolve("plugin.jar");
+         makeJar(pluginJar, DummyClass1.class);
+         Path dep1Dir = createTempDir();
+         Path dep1Jar = dep1Dir.resolve("dep1.jar");
+         makeJar(dep1Jar, DummyClass2.class);
+         Path dep2Dir = createTempDir();
+         Path dep2Jar = dep2Dir.resolve("dep2.jar");
+         makeJar(dep2Jar, DummyClass2.class);
+         Map<String, Set<URL>> transitiveDeps = new HashMap<>();
+         transitiveDeps.put("dep1", Collections.singleton(dep1Jar.toUri().toURL()));
+         transitiveDeps.put("dep2", Collections.singleton(dep2Jar.toUri().toURL()));
+         PluginInfo info1 = new PluginInfo(
+             "myplugin",
+             "desc",
+             "1.0",
+             Version.CURRENT,
+             "1.8",
+             "MyPlugin",
+             Arrays.asList("dep1", "dep2"),
+             false
+         );
+         PluginsService.Bundle bundle = new PluginsService.Bundle(info1, pluginDir);
+         IllegalStateException e = expectThrows(
+             IllegalStateException.class,
+             () -> PluginsService.checkBundleJarHell(JarHell.parseClassPath(), bundle, transitiveDeps)
+         );
+         assertEquals("failed to load plugin myplugin due to jar hell", e.getMessage());
+         assertThat(e.getCause().getMessage(), containsString("jar hell!"));
+         assertThat(e.getCause().getMessage(), containsString("DummyClass2"));
+     }
+
+     public void testJarHellTransitiveMap() throws Exception {
+         Path pluginDir = createTempDir();
+         Path pluginJar = pluginDir.resolve("plugin.jar");
+         makeJar(pluginJar, DummyClass1.class);
+         Path dep1Dir = createTempDir();
+         Path dep1Jar = dep1Dir.resolve("dep1.jar");
+         makeJar(dep1Jar, DummyClass2.class);
+         Path dep2Dir = createTempDir();
+         Path dep2Jar = dep2Dir.resolve("dep2.jar");
+         makeJar(dep2Jar, DummyClass3.class);
+         Map<String, Set<URL>> transitiveDeps = new HashMap<>();
+         transitiveDeps.put("dep1", Collections.singleton(dep1Jar.toUri().toURL()));
+         transitiveDeps.put("dep2", Collections.singleton(dep2Jar.toUri().toURL()));
+         PluginInfo info1 = new PluginInfo(
+             "myplugin",
+             "desc",
+             "1.0",
+             Version.CURRENT,
+             "1.8",
+             "MyPlugin",
+             Arrays.asList("dep1", "dep2"),
+             false
+         );
+         PluginsService.Bundle bundle = new PluginsService.Bundle(info1, pluginDir);
+         PluginsService.checkBundleJarHell(JarHell.parseClassPath(), bundle, transitiveDeps);
+         Set<URL> deps = transitiveDeps.get("myplugin");
+         assertNotNull(deps);
+         assertThat(deps, containsInAnyOrder(pluginJar.toUri().toURL(), dep1Jar.toUri().toURL(), dep2Jar.toUri().toURL()));
+     }
+
+     public void testNonExtensibleDep() throws Exception {
+         // This test opens a child classloader, reading a jar under the test temp
+         // dir (a dummy plugin). Classloaders are closed by GC, so when test teardown
+         // occurs the jar is deleted while the classloader is still open. However, on
+         // windows, files cannot be deleted when they are still open by a process.
+         assumeFalse("windows deletion behavior is asinine", Constants.WINDOWS);
+
+         Path homeDir = createTempDir();
+         Settings settings = Settings.builder().put(Environment.PATH_HOME_SETTING.getKey(), homeDir).build();
+         Path pluginsDir = homeDir.resolve("plugins");
+         Path mypluginDir = pluginsDir.resolve("myplugin");
+         PluginTestUtil.writePluginProperties(
+             mypluginDir,
+             "description",
+             "whatever",
+             "name",
+             "myplugin",
+             "version",
+             "1.0.0",
+             "opensearch.version",
+             Version.CURRENT.toString(),
+             "java.version",
+             System.getProperty("java.specification.version"),
+             "extended.plugins",
+             "nonextensible",
+             "classname",
+             "test.DummyPlugin"
+         );
+         try (InputStream jar = PluginsServiceTests.class.getResourceAsStream("dummy-plugin.jar")) {
+             Files.copy(jar, mypluginDir.resolve("plugin.jar"));
+         }
+         Path nonextensibleDir = pluginsDir.resolve("nonextensible");
+         PluginTestUtil.writePluginProperties(
+             nonextensibleDir,
+             "description",
+             "whatever",
+             "name",
+             "nonextensible",
+             "version",
+             "1.0.0",
+             "opensearch.version",
+             Version.CURRENT.toString(),
+             "java.version",
+             System.getProperty("java.specification.version"),
+             "classname",
+             "test.NonExtensiblePlugin"
+         );
+         try (InputStream jar = PluginsServiceTests.class.getResourceAsStream("non-extensible-plugin.jar")) {
+             Files.copy(jar, nonextensibleDir.resolve("plugin.jar"));
+         }
+         IllegalStateException e = expectThrows(IllegalStateException.class, () -> newPluginsService(settings));
+         assertEquals("Plugin [myplugin] cannot extend non-extensible plugin [nonextensible]", e.getMessage());
+     }
+
+     public void testIncompatibleOpenSearchVersion() throws Exception {
+         PluginInfo info = new PluginInfo(
+             "my_plugin",
+             "desc",
+             "1.0",
+             LegacyESVersion.fromId(6000099),
+             "1.8",
+             "FakePlugin",
+             Collections.emptyList(),
+             false
+         );
+         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginsService.verifyCompatibility(info));
+         assertThat(e.getMessage(), containsString("was built for OpenSearch version 6.0.0"));
+     }
+
+     public void testCompatibleOpenSearchVersionRange() {
+         List<SemverRange> pluginCompatibilityRange = List.of(new SemverRange(Version.CURRENT, SemverRange.RangeOperator.TILDE));
+         PluginInfo info = new PluginInfo(
+             "my_plugin",
+             "desc",
+             "1.0",
+             pluginCompatibilityRange,
+             "1.8",
+             "FakePlugin",
+             null,
+             Collections.emptyList(),
+             false
+         );
+         PluginsService.verifyCompatibility(info);
+     }
+
+     public void testIncompatibleOpenSearchVersionRange() {
+         // Version.CURRENT is behind by one with respect to patch version in the range
+         List<SemverRange> pluginCompatibilityRange = List.of(
+             new SemverRange(
+                 VersionUtils.getVersion(Version.CURRENT.major, Version.CURRENT.minor, (byte) (Version.CURRENT.revision + 1)),
+                 SemverRange.RangeOperator.TILDE
+             )
+         );
+         PluginInfo info = new PluginInfo(
+             "my_plugin",
+             "desc",
+             "1.0",
+             pluginCompatibilityRange,
+             "1.8",
+             "FakePlugin",
+             null,
+             Collections.emptyList(),
+             false
+         );
+         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginsService.verifyCompatibility(info));
+         assertThat(e.getMessage(), containsString("was built for OpenSearch version "));
+     }
+
+     public void testIncompatibleJavaVersion() throws Exception {
+         PluginInfo info = new PluginInfo(
+             "my_plugin",
+             "desc",
+             "1.0",
+             Version.CURRENT,
+             "1000000",
+             "FakePlugin",
+             Collections.emptyList(),
+             false
+         );
+         IllegalStateException e = expectThrows(IllegalStateException.class, () -> PluginsService.verifyCompatibility(info));
+         assertThat(e.getMessage(), containsString("my_plugin requires Java"));
+     }
+
+     public void testFindPluginDirs() throws Exception {
+         final Path plugins = createTempDir();
+
+         try (MockLogAppender mockLogAppender = MockLogAppender.createForLoggers(LogManager.getLogger(PluginsService.class))) {
+             mockLogAppender.addExpectation(
+                 new MockLogAppender.SeenEventExpectation(
+                     "[.test] warning",
+                     "org.opensearch.plugins.PluginsService",
+                     Level.WARN,
+                     "Non-plugin file located in the plugins folder with the following name: [.DS_Store]"
+                 )
+             );
+
+             final Path fake = plugins.resolve("fake");
+             Path testFile = plugins.resolve(".DS_Store");
+             Files.createFile(testFile);
+
+             PluginTestUtil.writePluginProperties(
+                 fake,
+                 "description",
+                 "description",
+                 "name",
+                 "fake",
+                 "version",
+                 "1.0.0",
+                 "opensearch.version",
+                 Version.CURRENT.toString(),
+                 "java.version",
+                 System.getProperty("java.specification.version"),
+                 "classname",
+                 "test.DummyPlugin"
+             );
+
+             try (InputStream jar = PluginsServiceTests.class.getResourceAsStream("dummy-plugin.jar")) {
+                 Files.copy(jar, fake.resolve("plugin.jar"));
+             }
+
+             assertThat(PluginsService.findPluginDirs(plugins), containsInAnyOrder(fake));
+             mockLogAppender.assertAllExpectationsMatched();
+         }
+     }
+
+     public void testExistingMandatoryClasspathPlugin() {
+         final Settings settings = Settings.builder()
+             .put("path.home", createTempDir())
+             .put("plugin.mandatory", "org.opensearch.plugins.PluginsServiceTests$FakePlugin")
+             .build();
+         newPluginsService(settings, FakePlugin.class);
+     }
+
+     public static class FakePlugin extends Plugin {
+
+         public FakePlugin() {
+
+         }
+
+     }
+
+     public void testExistingMandatoryInstalledPlugin() throws IOException {
+         // This test opens a child classloader, reading a jar under the test temp
+         // dir (a dummy plugin). Classloaders are closed by GC, so when test teardown
+         // occurs the jar is deleted while the classloader is still open. However, on
+         // windows, files cannot be deleted when they are still open by a process.
+         assumeFalse("windows deletion behavior is asinine", Constants.WINDOWS);
+         final Path pathHome = createTempDir();
+         final Path plugins = pathHome.resolve("plugins");
+         final Path fake = plugins.resolve("fake");
+
+         PluginTestUtil.writePluginProperties(
+             fake,
+             "description",
+             "description",
+             "name",
+             "fake",
+             "version",
+             "1.0.0",
+             "opensearch.version",
+             Version.CURRENT.toString(),
+             "java.version",
+             System.getProperty("java.specification.version"),
+             "classname",
+             "test.DummyPlugin"
+         );
+         try (InputStream jar = PluginsServiceTests.class.getResourceAsStream("dummy-plugin.jar")) {
+             Files.copy(jar, fake.resolve("plugin.jar"));
+         }
+
+         final Settings settings = Settings.builder().put("path.home", pathHome).put("plugin.mandatory", "fake").build();
+         newPluginsService(settings);
+     }
+
+     public void testPluginFromParentClassLoader() throws IOException {
+         final Path pathHome = createTempDir();
+         final Path plugins = pathHome.resolve("plugins");
+         final Path fake = plugins.resolve("fake");
+
+         PluginTestUtil.writePluginProperties(
+             fake,
+             "description",
+             "description",
+             "name",
+             "fake",
+             "version",
+             "1.0.0",
+             "opensearch.version",
+             Version.CURRENT.toString(),
+             "java.version",
+             System.getProperty("java.specification.version"),
+             "classname",
+             TestPlugin.class.getName()
+         ); // set a class defined outside the bundle (in parent class-loader of plugin)
+
+         final Settings settings = Settings.builder().put("path.home", pathHome).put("plugin.mandatory", "fake").build();
+         IllegalStateException exception = expectThrows(IllegalStateException.class, () -> newPluginsService(settings));
+         assertThat(
+             exception,
+             hasToString(
+                 containsString(
+                     "Plugin [fake] must reference a class loader local Plugin class ["
+                         + TestPlugin.class.getName()
+                         + "] (class loader ["
+                         + PluginsServiceTests.class.getClassLoader()
+                         + "])"
+                 )
+             )
+         );
+     }
+
+     public void testPluginLoadFailure() throws IOException {
+         final Path pathHome = createTempDir();
+         final Path plugins = pathHome.resolve("plugins");
+         final Path fake = plugins.resolve("fake");
+
+         PluginTestUtil.writePluginProperties(
+             fake,
+             "description",
+             "description",
+             "name",
+             "fake",
+             "version",
+             "1.0.0",
+             "opensearch.version",
+             Version.CURRENT.toString(),
+             "java.version",
+             System.getProperty("java.specification.version"),
+             "classname",
+             "DummyClass"
+         ); // This class is not present in Path, hence plugin loading will throw ClassNotFoundException
+
+         final Settings settings = Settings.builder().put("path.home", pathHome).put("plugin.mandatory", "fake").build();
+         RuntimeException exception = expectThrows(RuntimeException.class, () -> newPluginsService(settings));
+         assertTrue(exception.getCause() instanceof ClassNotFoundException);
+         assertThat(exception, hasToString(containsString("Unable to load plugin class [DummyClass]")));
+     }
+
+     public void testExtensiblePlugin() {
+         TestExtensiblePlugin extensiblePlugin = new TestExtensiblePlugin();
+         PluginsService.loadExtensions(
+             Collections.singletonList(
+                 Tuple.tuple(
+                     new PluginInfo("extensible", null, null, Version.CURRENT, null, null, Collections.emptyList(), false),
+                     extensiblePlugin
+                 )
+             )
+         );
+
+         assertThat(extensiblePlugin.extensions, notNullValue());
+         assertThat(extensiblePlugin.extensions, hasSize(0));
+
+         extensiblePlugin = new TestExtensiblePlugin();
+         TestPlugin testPlugin = new TestPlugin();
+         PluginsService.loadExtensions(
+             Arrays.asList(
+                 Tuple.tuple(
+                     new PluginInfo("extensible", null, null, Version.CURRENT, null, null, Collections.emptyList(), false),
+                     extensiblePlugin
+                 ),
+                 Tuple.tuple(
+                     new PluginInfo("test", null, null, Version.CURRENT, null, null, Collections.singletonList("extensible"), false),
+                     testPlugin
+                 )
+             )
+         );
+
+         assertThat(extensiblePlugin.extensions, notNullValue());
+         assertThat(extensiblePlugin.extensions, hasSize(2));
+         assertThat(extensiblePlugin.extensions.get(0), instanceOf(TestExtension1.class));
+         assertThat(extensiblePlugin.extensions.get(1), instanceOf(TestExtension2.class));
+         assertThat(((TestExtension2) extensiblePlugin.extensions.get(1)).plugin, sameInstance(testPlugin));
+     }
+
+     public void testNoExtensionConstructors() {
+         TestPlugin plugin = new TestPlugin();
+         class TestExtension implements TestExtensionPoint {
+             private TestExtension() {}
+         }
+         IllegalStateException e = expectThrows(IllegalStateException.class, () -> {
+             PluginsService.createExtension(TestExtension.class, TestExtensionPoint.class, plugin);
+         });
+
+         assertThat(
+             e,
+             hasToString(
+                 containsString(
+                     "no public constructor for extension ["
+                         + TestExtension.class.getName()
+                         + "] of type ["
+                         + TestExtensionPoint.class.getName()
+                         + "]"
+                 )
+             )
+         );
+     }
+
+     public void testMultipleExtensionConstructors() {
+         TestPlugin plugin = new TestPlugin();
+         class TestExtension implements TestExtensionPoint {
+             public TestExtension() {}
+
+             public TestExtension(TestPlugin plugin) {
+
+             }
+         }
+         IllegalStateException e = expectThrows(IllegalStateException.class, () -> {
+             PluginsService.createExtension(TestExtension.class, TestExtensionPoint.class, plugin);
+         });
+
+         assertThat(
+             e,
+             hasToString(
+                 containsString(
+                     "no unique public constructor for extension ["
+                         + TestExtension.class.getName()
+                         + "] of type ["
+                         + TestExtensionPoint.class.getName()
+                         + "]"
+                 )
+             )
+         );
+     }
+
+     public void testBadSingleParameterConstructor() {
+         TestPlugin plugin = new TestPlugin();
+         IllegalStateException e = expectThrows(IllegalStateException.class, () -> {
+             PluginsService.createExtension(BadSingleParameterConstructorExtension.class, TestExtensionPoint.class, plugin);
+         });
+
+         assertThat(
+             e,
+             hasToString(
+                 containsString(
+                     "signature of constructor for extension ["
+                         + BadSingleParameterConstructorExtension.class.getName()
+                         + "] of type ["
+                         + TestExtensionPoint.class.getName()
+                         + "] must be either () or ("
+                         + TestPlugin.class.getName()
+                         + "), not ("
+                         + String.class.getName()
+                         + ")"
+                 )
+             )
+         );
+     }
+
+     public void testTooManyParametersExtensionConstructors() {
+         TestPlugin plugin = new TestPlugin();
+         IllegalStateException e = expectThrows(IllegalStateException.class, () -> {
+             PluginsService.createExtension(TooManyParametersConstructorExtension.class, TestExtensionPoint.class, plugin);
+         });
+
+         assertThat(
+             e,
+             hasToString(
+                 containsString(
+                     "signature of constructor for extension ["
+                         + TooManyParametersConstructorExtension.class.getName()
+                         + "] of type ["
+                         + TestExtensionPoint.class.getName()
+                         + "] must be either () or ("
+                         + TestPlugin.class.getName()
+                         + ")"
+                 )
+             )
+         );
+     }
+
+     public void testThrowingConstructor() {
+         TestPlugin plugin = new TestPlugin();
+         IllegalStateException e = expectThrows(IllegalStateException.class, () -> {
+             PluginsService.createExtension(ThrowingConstructorExtension.class, TestExtensionPoint.class, plugin);
+         });
+
+         assertThat(
+             e,
+             hasToString(
+                 containsString(
+                     "failed to create extension ["
+                         + ThrowingConstructorExtension.class.getName()
+                         + "] of type ["
+                         + TestExtensionPoint.class.getName()
+                         + "]"
+                 )
+             )
+         );
+         assertThat(e.getCause(), instanceOf(InvocationTargetException.class));
+         assertThat(e.getCause().getCause(), instanceOf(IllegalArgumentException.class));
+         assertThat(e.getCause().getCause(), hasToString(containsString("test constructor failure")));
+     }
+
+     public void testPluginCompatibilityWithSemverRange() {
+         // Compatible plugin and core versions
+         assertTrue(PluginsService.isPluginVersionCompatible(getPluginInfoWithWithSemverRange("1.0.0"), Version.fromString("1.0.0")));
+
+         assertTrue(PluginsService.isPluginVersionCompatible(getPluginInfoWithWithSemverRange("=1.0.0"), Version.fromString("1.0.0")));
+
+         assertTrue(PluginsService.isPluginVersionCompatible(getPluginInfoWithWithSemverRange("~1.0.0"), Version.fromString("1.0.0")));
+
+         assertTrue(PluginsService.isPluginVersionCompatible(getPluginInfoWithWithSemverRange("~1.0.1"), Version.fromString("1.0.2")));
+
+         // Incompatible plugin and core versions
+         assertFalse(PluginsService.isPluginVersionCompatible(getPluginInfoWithWithSemverRange("1.0.0"), Version.fromString("1.0.1")));
+
+         assertFalse(PluginsService.isPluginVersionCompatible(getPluginInfoWithWithSemverRange("=1.0.0"), Version.fromString("1.0.1")));
+
+         assertFalse(PluginsService.isPluginVersionCompatible(getPluginInfoWithWithSemverRange("~1.0.1"), Version.fromString("1.0.0")));
+
+         assertFalse(PluginsService.isPluginVersionCompatible(getPluginInfoWithWithSemverRange("~1.0.0"), Version.fromString("1.1.0")));
+     }
+
+     private PluginInfo getPluginInfoWithWithSemverRange(String semverRange) {
+         return new PluginInfo(
+             "my_plugin",
+             "desc",
+             "1.0",
+             List.of(SemverRange.fromString(semverRange)),
+             "1.8",
+             "FakePlugin",
+             null,
+             Collections.emptyList(),
+             false
+         );
+     }
 
     private static class TestExtensiblePlugin extends Plugin implements ExtensiblePlugin {
         private List<TestExtensionPoint> extensions;
@@ -1182,5 +1208,56 @@ public class PluginsServiceTests extends OpenSearchTestCase {
         public ThrowingConstructorExtension() {
             throw new IllegalArgumentException("test constructor failure");
         }
+    }
+
+    @Test
+    public void test_isShardSplitAllowed_BothAllowedNotAllowed() {
+
+        PluginsService service = newPluginsServiceSplit(Settings.EMPTY, ShardSplitNotAllowedPlugin.class, ShardSplitAllowedPlugin.class);
+
+        // Arrange
+        Index testIndex = new Index("test-index", "uuid");
+
+        // Act
+        Tuple<Boolean, String> result = service.isShardSplitAllowed(testIndex);
+
+        // Assert
+        assertFalse("Shard split should not be allowed" + result.v1(), result.v1());
+        assertNotNull("Message should not be null", result.v2());
+        assertTrue("Message should contain unsupported plugins", result.v2().contains("ShardSplitNotAllowedPlugin"));
+        assertFalse("Message should not contain supported plugins", result.v2().contains("ShardSplitAllowedPlugin"));
+    }
+
+    @Test
+    public void test_isShardSplitAllowed_OnlyAllowed() {
+
+        PluginsService service = newPluginsServiceSplit(Settings.EMPTY, ShardSplitAllowedPlugin.class);
+
+        // Arrange
+        Index testIndex = new Index("test-index", "uuid");
+
+        // Act
+        Tuple<Boolean, String> result = service.isShardSplitAllowed(testIndex);
+
+        // Assert
+        assertTrue("Shard split should be allowed", result.v1());
+        assertNull("Message should be null when split is allowed", result.v2());
+    }
+
+    @Test
+    public void test_isShardSplitAllowed_OnlyNotAllowed() {
+
+        PluginsService service = newPluginsServiceSplit(Settings.EMPTY, ShardSplitNotAllowedPlugin.class);
+
+        // Arrange
+        Index testIndex = new Index("test-index", "uuid");
+
+        // Act
+        Tuple<Boolean, String> result = service.isShardSplitAllowed(testIndex);
+
+        // Assert
+        assertFalse("Shard split should not be allowed", result.v1());
+        assertNotNull("Message should not be null", result.v2());
+        assertTrue("Message should contain unsupported plugins", result.v2().contains("ShardSplitNotAllowedPlugin"));
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Adding UTs for split changes for worker for the following classes:

- SplitShardsMetatdata
- ShardRange
- RoutingTable
- RoutingNode
- IndexShardRoutingTable
- ShardRouting
- PluginsService
- IndexRoutingTable (covered through RoutingTable UTs)

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
