### PR TITLE
sets routingNumShards to numberOfRootShards

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/IndexMetadata.java
@@ -1496,7 +1496,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
          * @see #numberOfShards()
          */
         public int getRoutingNumShards() {
-            return routingNumShards == null ? numberOfShards() : routingNumShards;
+            return routingNumShards == null ? numberOfRootShards() : routingNumShards;
         }
 
         /**
@@ -1506,6 +1506,17 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
          */
         public int numberOfShards() {
             return settings.getAsInt(SETTING_NUMBER_OF_SHARDS, -1);
+        }
+
+        /**
+        * Returns the number of root shards. This value will differ from the value returned by 
+        * numberOfShards() if splits have occrred on any shards of the index
+        *
+        * @return number of root shards
+        *
+        **/ 
+        public int numberOfRootShards() {
+            return splitShardsMetadata == null ? numberOfShards() : splitShardsMetadata.getNumberOfRootShards();
         }
 
         public Builder updateMetadataForNewChildShards(Map<Integer, String> newChildAllocationIds, int sourceShardId) {


### PR DESCRIPTION
Since numberOfShards will change after shards have been split we cannot use that value to set routingNumShards as this will alter the routingFactor of the index.

numberOfRootShards() will always return the original number of shards that were present in the index before any split had run.

<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
