### PR TITLE
Fix shard range calculation

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/metadata/SplitShardsMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/SplitShardsMetadata.java
@@ -174,10 +174,13 @@ public class SplitShardsMetadata extends AbstractDiffable<SplitShardsMetadata> i
         };
     }
 
-    private static void validateShardRanges(int shardId, ShardRange[] shardRanges, long parentStart, long parentEnd) {
+    // Visible for testing
+    static void validateShardRanges(int shardId, ShardRange[] shardRanges) {
         Integer start = null;
+        int lowerBound = Integer.MIN_VALUE;
+        int upperBound = Integer.MAX_VALUE;
         for (ShardRange shardRange : shardRanges) {
-            validateBounds(shardRange, start, parentStart);
+            validateBounds(shardRange, start, lowerBound);
             long rangeEnd = shardRange.getEnd();
             long rangeLength = rangeEnd - shardRange.getStart() + 1;
             if (rangeLength < MINIMUM_RANGE_LENGTH_THRESHOLD) {
@@ -193,9 +196,9 @@ public class SplitShardsMetadata extends AbstractDiffable<SplitShardsMetadata> i
             throw new IllegalArgumentException("No shard range defined for child shards of shard " + shardId);
         }
 
-        if (start != parentEnd) {
+        if (start != upperBound) {
             throw new IllegalArgumentException(
-                "Shard range from " + (start + 1) + " to " + parentEnd
+                "Shard range from " + (start + 1) + " to " + upperBound
                     + " is missing from the list of shard ranges");
         }
     }
@@ -208,9 +211,14 @@ public class SplitShardsMetadata extends AbstractDiffable<SplitShardsMetadata> i
                         + " is missing from the list of shard ranges");
             }
         } else if (shardRange.getStart() != start + 1) {
-            throw new IllegalArgumentException(
-                "Shard range from " + (start + 1) + " to " + (shardRange.getStart() - 1)
-                    + " is missing from the list of shard ranges");
+            String errorMessage;
+            if (shardRange.getStart() < start + 1) {
+                errorMessage = "Shard range overlaps from " + shardRange.getStart() + " to " + start;
+            } else {
+                errorMessage = "Shard range from " + (start + 1) + " to " + (shardRange.getStart() - 1)
+                    + " is missing from the list of shard ranges";
+            }
+            throw new IllegalArgumentException(errorMessage);
         }
     }
 
@@ -270,7 +278,7 @@ public class SplitShardsMetadata extends AbstractDiffable<SplitShardsMetadata> i
             }
             ShardRange parentShard = shardTuple.v2();
 
-            long rangeSize = ((long)parentShard.getEnd() - parentShard.getStart()) / numberOfChildren;
+            long rangeSize = ((long)parentShard.getEnd() - parentShard.getStart() + 1 ) / numberOfChildren;
 
             if(rangeSize <= MINIMUM_RANGE_LENGTH_THRESHOLD) {
                 throw new IllegalArgumentException("Cannot split shard [" + splitShardId + "] further.");
@@ -280,15 +288,23 @@ public class SplitShardsMetadata extends AbstractDiffable<SplitShardsMetadata> i
             List<ShardRange> newChildShardsList = new ArrayList<>();
             int nextChildShardId = maxShardId + 1;
             for (int i = 0; i < numberOfChildren; ++i) {
-                long end = i == numberOfChildren - 1 ? parentShard.getEnd() : start + rangeSize;
+                long end = i == numberOfChildren - 1 ? parentShard.getEnd() : start + rangeSize - 1;
                 int childShardId = nextChildShardId++;
                 ShardRange childShard = new ShardRange(childShardId, (int) start, (int) end);
                 newChildShardsList.add(childShard);
                 start = end + 1;
             }
             ShardRange[] newShardRanges = newChildShardsList.toArray(new ShardRange[0]);
-            validateShardRanges(splitShardId, newShardRanges, parentShard.getStart(), parentShard.getEnd());
 
+//            // Get existing childShardRanges under rootShard
+            List<ShardRange> shardsUnderRoot = rootShardsToAllChildren[shardTuple.v1()] == null ? new ArrayList<>() :
+                new ArrayList<>(Arrays.asList(rootShardsToAllChildren[shardTuple.v1()]));
+            shardsUnderRoot.remove(shardTuple.v2()); // Remove parent shard range
+            shardsUnderRoot.addAll(List.of(newShardRanges)); // Add child shard range
+            ShardRange[] newShardsUnderRoot = shardsUnderRoot.toArray(new ShardRange[0]);
+            Arrays.sort(newShardsUnderRoot);
+
+            validateShardRanges(splitShardId, newShardsUnderRoot);
             parentToChildShards.put(splitShardId, newShardRanges);
         }
 
@@ -307,7 +323,7 @@ public class SplitShardsMetadata extends AbstractDiffable<SplitShardsMetadata> i
             shardsUnderRoot.addAll(Arrays.asList(parentToChildShards.get(sourceShardId)));
             ShardRange[] newShardsUnderRoot = shardsUnderRoot.toArray(new ShardRange[0]);
             Arrays.sort(newShardsUnderRoot);
-            validateShardRanges(shardRangeTuple.v1(), newShardsUnderRoot, Integer.MIN_VALUE, Integer.MAX_VALUE);
+            validateShardRanges(shardRangeTuple.v1(), newShardsUnderRoot);
 
             maxShardId += newChildShardIds.size();
             rootShardsToAllChildren[shardRangeTuple.v1()] = newShardsUnderRoot;

--- a/server/src/test/java/org/opensearch/cluster/metadata/SplitShardsMetadataTests.java
+++ b/server/src/test/java/org/opensearch/cluster/metadata/SplitShardsMetadataTests.java
@@ -13,6 +13,7 @@ import org.opensearch.test.OpenSearchTestCase;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.when;
+import static org.opensearch.cluster.metadata.SplitShardsMetadata.validateShardRanges;
 
 public class SplitShardsMetadataTests extends OpenSearchTestCase {
 
@@ -658,15 +659,6 @@ public class SplitShardsMetadataTests extends OpenSearchTestCase {
     }
 
     @Test
-    public void testSplitShardWithInvalidChildren() {
-        SplitShardsMetadata.Builder builder = new SplitShardsMetadata.Builder(1);
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
-            builder.splitShard(0, 1000000);
-        });
-        assertTrue(exception.getMessage().contains(" is below shard range threshold of "));
-    }
-
-    @Test
     public void testSplitInvalidShardId() {
         SplitShardsMetadata.Builder builder = new SplitShardsMetadata.Builder(1);
         IllegalArgumentException exception = assertThrows(
@@ -741,8 +733,8 @@ public class SplitShardsMetadataTests extends OpenSearchTestCase {
             parentRange.getEnd(), secondLevelShards[secondLevelShards.length - 1].getEnd());
 
         // Test hash routing through the nested structure
-        int hashInFirstThird = parentRange.getStart() +
-            (parentRange.getEnd() - parentRange.getStart()) / 3;
+        long rangeSize = ((long) parentRange.getEnd() - (long) parentRange.getStart() + 1) / 3;
+        int hashInFirstThird = (parentRange.getStart() + (int) rangeSize) - 1;
 
         assertEquals("Hash should route to first child of nested split",
             3, metadata.getShardIdOfHash(0, hashInFirstThird, true));
@@ -924,6 +916,70 @@ public class SplitShardsMetadataTests extends OpenSearchTestCase {
             metadata1.equals(metadata2));
     }
 
+    @Test
+    public void testValidateShardRangesOverlap() {
+        // Test overlapping ranges
+        ShardRange[] overlappingRanges = new ShardRange[] {
+            new ShardRange(0,Integer.MIN_VALUE, 100),
+            new ShardRange(0,50, Integer.MAX_VALUE)  // Overlaps with previous range at 50-100
+        };
 
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> validateShardRanges(0, overlappingRanges)
+        );
+        assertTrue(exception.getMessage().contains("Shard range overlap"));
+    }
+
+    @Test
+    public void testValidateShardRangesBelowThreshold() {
+        // Test range below threshold
+        ShardRange[] smallRange = new ShardRange[] {
+            new ShardRange(0, Integer.MIN_VALUE, Integer.MIN_VALUE + 10)
+        };
+
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> validateShardRanges(0, smallRange)
+        );
+        assertTrue(exception.getMessage().contains("below shard range threshold"));
+    }
+
+    @Test
+    public void testValidateShardRangesMissingRange() {
+        // Test missing range
+        ShardRange[] missingRange = new ShardRange[] {
+            new ShardRange(0, Integer.MIN_VALUE, 100),
+            new ShardRange(0, 200, Integer.MAX_VALUE)  // Missing range at 101-199
+        };
+
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> validateShardRanges(0, missingRange)
+        );
+        System.out.println(exception.getMessage());
+        assertTrue(exception.getMessage().contains("Shard range from 101 to 199 is missing from the list of shard ranges"));
+    }
+
+    @Test
+    public void testValidateShardRangesInvalidStartRange() {
+        // test shard range not at Integer.Min
+        ShardRange[] missingRange = new ShardRange[] {
+            new ShardRange(0, Integer.MIN_VALUE + 1, 100),
+            new ShardRange(0, 100, Integer.MAX_VALUE)  // Missing range at 101-199
+        };
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> validateShardRanges(0, missingRange)
+        );
+        assertTrue(exception.getMessage().contains("Shard range from -2147483648 to -2147483648 is missing from the list of shard ranges"));
+
+
+        // Empty shard range
+        IllegalArgumentException exception2 = assertThrows(
+            IllegalArgumentException.class,
+            () -> validateShardRanges(0,new ShardRange[0]));
+        assertTrue(exception2.getMessage().contains("No shard range defined for child shards of shard 0"));
+    }
 
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
1. Fix shard range size calculation to calculate range size to include the boundaries in range.

ParentShard Range  [0-9]
numChidShard = 2
RangeSize =  (9 - 0 + 1) /2  =  5


2. Fix shard range distribution to distribute range based on correct rangeSize and not allocate boundary

childShard1 [0, 4]
childShard2 [5, 9]

3. Add validation to validate entire shard range from Int.MIN to Int.Max


### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
